### PR TITLE
Sync the strides and size of DNNL tensor to its aten::tensor wrapper

### DIFF
--- a/cmake/CPU.cmake
+++ b/cmake/CPU.cmake
@@ -16,7 +16,7 @@ add_subdirectory(${DPCPP_THIRD_PARTY_ROOT}/mkl-dnn)
 # Define build type
 IF(CMAKE_BUILD_TYPE MATCHES Debug)
   message("Debug build.")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O0 -g")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O0 -g -D_DEBUG")
 ELSE()
   message("Release build.")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O2")

--- a/tests/cpu/test_lazy_reorder.py
+++ b/tests/cpu/test_lazy_reorder.py
@@ -749,6 +749,33 @@ class TestTensorShape(TestCase):
                     x_dpcpp.transpose(dim1, dim2),
                 )
 
+    def test_view(self):
+        ipex.enable_auto_dnnl()
+        old_shape = (4, 16)
+        new_shape = (1, 4, 4, 4)
+
+        x_cpu = torch.randn(old_shape)
+        x_dpcpp = x_cpu.to(device=device).clone()
+        print(x_dpcpp.size())
+
+        x_cpu_view = x_cpu.view(new_shape)
+        print(x_cpu_view.size())
+        x_dpcpp_view = x_dpcpp.view(new_shape)
+        print(x_dpcpp_view.size())
+        
+        y = torch.randn(new_shape)
+        out_cpu = x_cpu_view * y
+        # test if the shape of x_dpcpp_view is compatible with y
+        out_dpcpp = x_dpcpp_view * y
+        self.assertEqual(out_cpu, out_dpcpp)
+
+        # test if metadata of x_dpcpp has not been altered
+        y = torch.randn(old_shape)
+        out_cpu = x_cpu * y
+        out_dpcpp = x_dpcpp * y
+        self.assertEqual(out_cpu, out_dpcpp)
+
+
 class TestSoftMax(TestCase):
     def test_softmax(self):
         ipex.enable_auto_dnnl()

--- a/tests/cpu/test_rn50_cpu_ops.py
+++ b/tests/cpu/test_rn50_cpu_ops.py
@@ -416,6 +416,9 @@ class TestOP(TestCase):
         self.assertRaises(RuntimeError, lambda: tensor.view(7, -1))
         self.assertRaises(RuntimeError, lambda: tensor.view(15, -1, -1))
 
+        # TODO(Eikan): DNNL OP does not support >6 dim tensor, so we disable it temporily. When we fix it, we will open it
+        old_dnnl_conf = ipex.get_auto_dnnl()
+        ipex.disable_auto_dnnl()
         # test view when tensor is not contiguous in every dimension, but only
         # contiguous dimensions are touched.
         tensor = torch.rand(4, 2, 5, 1, 6, 2, 9, 3, device=device).transpose(-1, 2).transpose(-2, 3)
@@ -441,6 +444,10 @@ class TestOP(TestCase):
         # adding size 1 dims
         view_size = [1, 1, 2, 1, 4, 3, 1, 1, 9, 1, 2, 1, 2, 3, 1, 5, 1, 1]
         self.assertEqual(tensor.view(*view_size), contig_tensor.view(*view_size))
+        if old_dnnl_conf:
+            ipex.enable_auto_dnnl()
+        else:
+            ipex.disable_auto_dnnl()
 
         # invalid views
         self.assertRaises(RuntimeError, lambda: tensor.view(-1))

--- a/torch_ipex/csrc/aten_ipex_bridge.cpp
+++ b/torch_ipex/csrc/aten_ipex_bridge.cpp
@@ -18,6 +18,7 @@
 namespace torch_ipex {
 namespace bridge {
 
+#if defined(_DEBUG)
 #define CHECK_TENSOR(a, b) \
   TORCH_INTERNAL_ASSERT(a.numel() == b.numel()); \
   TORCH_INTERNAL_ASSERT(a.dtype() == b.dtype()); \
@@ -30,13 +31,21 @@ namespace bridge {
   TORCH_INTERNAL_ASSERT(a.unsafeGetTensorImpl()->is_wrapped_number() == b.unsafeGetTensorImpl()->is_wrapped_number()); \
   TORCH_INTERNAL_ASSERT(a.unsafeGetTensorImpl()->version_counter().current_version() == b.unsafeGetTensorImpl()->version_counter().current_version()); \
   TORCH_INTERNAL_ASSERT(a.unsafeGetTensorImpl()->allow_tensor_metadata_change() == b.unsafeGetTensorImpl()->allow_tensor_metadata_change())
+#else
+#define CHECK_TENSOR(a, b) ((void) 0)
+#endif
 
+#if defined(_DEBUG)
 #define CHECK_TENSOR_CRITICAL(a, b, may_alias) \
   TORCH_INTERNAL_ASSERT(!may_alias || a.data_ptr() == b.data_ptr()); \
   TORCH_INTERNAL_ASSERT(a.unsafeGetTensorImpl()->strides() == b.unsafeGetTensorImpl()->strides()); \
   TORCH_INTERNAL_ASSERT(a.unsafeGetTensorImpl()->storage_offset() == b.unsafeGetTensorImpl()->storage_offset()); \
   CHECK_TENSOR(a, b)
+#else
+#define CHECK_TENSOR_CRITICAL(a, b, may_alias) ((void) 0)
+#endif
 
+#if defined(_DEBUG)
 #define CHECK_SPARSE_TENSOR_CRITICAL(a, b, may_alias) \
   TORCH_INTERNAL_ASSERT(!may_alias || a._indices().data_ptr() == b._indices().data_ptr()); \
   TORCH_INTERNAL_ASSERT(!may_alias || a._values().data_ptr() == b._values().data_ptr()); \
@@ -46,7 +55,9 @@ namespace bridge {
   TORCH_INTERNAL_ASSERT(a.is_coalesced() == b.is_coalesced()); \
   CHECK_TENSOR(a._indices(), b._indices()); \
   CHECK_TENSOR(a._values(), b._values())
-
+#else
+#define CHECK_SPARSE_TENSOR_CRITICAL(a, b, may_alias) ((void) 0)
+#endif
 
 at::Tensor shallowFallbackToCPUTensorImpl(const at::Tensor& ipexTensor);
 
@@ -58,31 +69,39 @@ void reorderDilTensorToPublic(const at::Tensor& ipexTensor) {
   TORCH_INTERNAL_ASSERT(! (shade_data_context->dil_tensor.is_empty()));
   dil::tensor &dil_tensor = shade_data_context->dil_tensor;
 
-  dil::dims sizes = dil_tensor.get_dims();
-  dil::dims strides;
-
   if (dil_tensor.is_public_format()) {
+#if defined(_DEBUG)
     TORCH_INTERNAL_ASSERT(shade_data_context->cpu_raw_data == shade_data_context->dil_tensor.get_data_handle());
     TORCH_INTERNAL_ASSERT(shade_data_context->cpu_raw_data != nullptr);
     TORCH_INTERNAL_ASSERT(shade_data_context->cpu_del_fun != nullptr);
-    strides = dil_tensor.get_strides();
+#endif
   } else {
-    auto dims = dil_tensor.get_dims();
-    // NOTE: int32_t dims from ideep::tensor but sizes needs int64_t
-    at::Tensor cpu_tensor = at::empty(
-      sizes, ipexTensor.options().device(c10::kCPU).layout(c10::kStrided));
-    TORCH_INTERNAL_ASSERT(cpu_tensor.scalar_type() == get_at_data_type(dil_tensor.get_data_type()));
-    auto pub_tensor = dil_tensor.to_public(cpu_tensor.data_ptr(), dil_tensor.get_data_type());
-    strides = pub_tensor.get_strides();
-    at::DataPtr& cpu_tensor_data_ptr = cpu_tensor.unsafeGetTensorImpl()->storage().unsafeGetStorageImpl()->data_ptr();
-    ipexTensor.unsafeGetTensorImpl()->storage().set_data_ptr(std::move(cpu_tensor_data_ptr));
-    // The tensor has been reset to new DataPtr, then we need to attach new shade data context.
-    attachShadeDataConext(ipexTensor);
+#if defined(_DEBUG)
+    auto& data_ptr = ipexTensor.storage().unsafeGetStorageImpl()->data_ptr();
+    TORCH_INTERNAL_ASSERT(data_ptr.get_deleter() == &(cpu::ShadeDataContext::freeShadeDataContext));
+    TORCH_INTERNAL_ASSERT(shade_data_context->cpu_del_fun == nullptr);
+#endif
+    auto pub_tensor = dil_tensor.to_public(nullptr, dil_tensor.get_data_type());
+
+    cpu::ShadeDataContext *new_shade_data_context = cpu::ShadeDataContext::allocShadeDataContext();
+    new_shade_data_context->data_type = cpu::SHADE_DATA_TYPE::DIL;
+    new_shade_data_context->dil_tensor = pub_tensor;
+    // Share with DNNL raw data because it is plain format now
+    new_shade_data_context->cpu_raw_data = pub_tensor.get_data_handle();
+    // Cannot free CPU data because the the data is owned by DNNL
+    new_shade_data_context->cpu_del_fun = &(c10::detail::deleteNothing);
+
+    // Create a new DataPtr instances because the DataPtr class does not support set
+    // its data or context directly
+    c10::DataPtr shade_data_ptr(
+      pub_tensor.get_data_handle(),
+      new_shade_data_context,
+      &(cpu::ShadeDataContext::freeShadeDataContext),
+      ipexTensor.device().type());
+
+    ipexTensor.unsafeGetTensorImpl()->storage().set_data_ptr(std::move(shade_data_ptr));
     TORCH_INTERNAL_ASSERT(ipexTensor.is_contiguous());
   }
-
-  auto* ipexTensorImpl = (IPEXTensorImpl *)ipexTensor.unsafeGetTensorImpl();
-  ipexTensorImpl->force_set_strided(sizes, strides);
 }
 
 

--- a/torch_ipex/csrc/cpu/ShadeDataContext.h
+++ b/torch_ipex/csrc/cpu/ShadeDataContext.h
@@ -90,7 +90,9 @@ struct ShadeDataContext {
     TORCH_INTERNAL_ASSERT((data_type == SHADE_DATA_TYPE::CPU_RAW) || (data_type == SHADE_DATA_TYPE::DIL));
 
     if (data_type == SHADE_DATA_TYPE::DIL) {
+#if defined(_DEBUG)
       TORCH_WARN(tensor.is_contiguous());
+#endif
       auto raw_cpu_data = tensor.storage().data_ptr().get();
       if (raw_cpu_data == nullptr) {
         // the dnnl tensor does not share data with raw tensor data.

--- a/torch_ipex/csrc/cpu/dbl/Common.cpp
+++ b/torch_ipex/csrc/cpu/dbl/Common.cpp
@@ -86,6 +86,14 @@ at::Tensor empty_dil_tensor(at::IntArrayRef sizes, const at::TensorOptions& opti
   return gen_aten_tensor_by(it);
 }
 
+void sync_shape_from_dil_to_aten(const at::Tensor& ipex_tensor, const dil::tensor &dil_tensor) {
+  dil::dims sizes = dil_tensor.get_dims();
+  dil::dims strides = dil_tensor.get_strides();
+  TORCH_INTERNAL_ASSERT(ipex_tensor.device().type() == at::DeviceType::DPCPP);
+  auto* _tensor_impl = (IPEXTensorImpl *)ipex_tensor.unsafeGetTensorImpl();
+  _tensor_impl->force_set_strided(sizes, strides);
+}
+
 }  // namespace comm
 }  // namespace dbl
 }  // namespace cpu

--- a/torch_ipex/csrc/cpu/dbl/Common.h
+++ b/torch_ipex/csrc/cpu/dbl/Common.h
@@ -14,6 +14,7 @@ at::Tensor dil_tensor_to_dense(const at::Tensor& tensor);
 dil::tensor try_gen_dil_tensor(const at::Tensor &input);
 at::Tensor gen_aten_tensor_by(dil::tensor tensor);
 at::Tensor empty_dil_tensor(at::IntArrayRef sizes, const at::TensorOptions& options);
+void sync_shape_from_dil_to_aten(const at::Tensor& ipex_tensor, const dil::tensor &dil_tensor);
 
 }  // namespace comm
 }  // namespace dbl

--- a/torch_ipex/csrc/cpu/dbl/DNNLChecker.cpp
+++ b/torch_ipex/csrc/cpu/dbl/DNNLChecker.cpp
@@ -9,12 +9,13 @@ namespace dbl {
 namespace chk {
 
 bool dnnl_support_the_tensors(const std::vector<at::Tensor> &tensor_vec) {
-  return dnnl_support_the_dimension_of(tensor_vec) &&
+  return dnnl_tensor_has_data(tensor_vec) &&
+         dnnl_support_the_dimension_of(tensor_vec) &&
          dnnl_support_the_data_type_of(tensor_vec);
 }
 
 bool dnnl_inplace_support_the_tensors(const std::vector<at::Tensor> &tensor_vec) {
-  return dnnl_support_the_dimension_of(tensor_vec) &&
+  return dnnl_tensor_has_data(tensor_vec) &&
          dnnl_support_the_data_type_of(tensor_vec) &&
          dnnl_support_the_memory_layout_of(tensor_vec);
 }
@@ -49,6 +50,14 @@ bool dnnl_support_the_dimension_of(const std::vector<at::Tensor> &tensor_vec) {
       return false;
     }
   }
+
+  return true;
+}
+
+bool dnnl_tensor_has_data(const std::vector<at::Tensor> &tensor_vec) {
+  for (auto it = tensor_vec.begin(); it != tensor_vec.end(); ++it)
+    if (it->data_ptr() == nullptr)
+      return false;
 
   return true;
 }

--- a/torch_ipex/csrc/cpu/dbl/DNNLChecker.h
+++ b/torch_ipex/csrc/cpu/dbl/DNNLChecker.h
@@ -61,6 +61,14 @@ bool dnnl_support_the_data_type_of(const std::vector<at::Tensor> &tensor_vec);
  */
 bool dnnl_support_the_dimension_of(const std::vector<at::Tensor> &tensor_vec);
 
+/**
+ * Check if the input tensor has data
+ *
+ * @param tensor_vec input tensors
+ *
+ */
+static inline bool dnnl_tensor_has_data(const std::vector<at::Tensor> &tensor_vec);
+
 }  // namespace chk
 }  // namespace dbl
 }  // namespace cpu

--- a/torch_ipex/csrc/utils.cpp
+++ b/torch_ipex/csrc/utils.cpp
@@ -80,7 +80,9 @@ dil::data_type get_dil_data_type(at::ScalarType at_dt) {
   }  else if (at_dt == at::ScalarType::QUInt8) {
     return dil::data_type::u8;
   } else {
+#if defined(_DEBUG)
     TORCH_WARN("DNNL does not support current data type.");
+#endif
     return dil::data_type::undef;
   }
 }
@@ -109,7 +111,8 @@ bool check_tensor_own_whole_storage(const at::Tensor& tensor) {
     return false;
 
   return (tensor.storage_offset() == 0) &&
-         (tensor.numel() == tensor.storage().numel());
+         (tensor.numel() == tensor.storage().numel()) &&
+         (tensor.itemsize() == tensor.storage().itemsize());
 }
 
 bool check_tensor_own_shade_context(const at::Tensor& tensor) {


### PR DESCRIPTION
We should just take the DNNL tensor as the buffer of aten tensor. It means that the shape information for OP computation should come from aten tensor but not its buffer - DNNL tensor. Then we can refine DNNL OP as follows.
- Attach the shape meta info of aten tensor to DNNL tensor at the DNNL OP entry point
- Write the shape meta info of DNNL tensor back to its aten tensor wrapper.

Besides that, if the OP(ex, slice, view) could change the shape of a tensor, its input tensors will always be reordered to a public format. Then its output tensors will be the plain format.
