### PR TITLE
Sync shape info between dil tensor and aten tensor

### DIFF
--- a/scripts/cpu/gen-dense-cpu-ops.py
+++ b/scripts/cpu/gen-dense-cpu-ops.py
@@ -306,7 +306,8 @@ class DenseOPCodeGen(object):
                     if param_var == 'out' and is_out_func(fname):
                         code += '      TORCH_INTERNAL_ASSERT({}.is_contiguous());\n'.format(param_var)
                     else:
-                        param_seq_str = '{}.is_contiguous() ? {} : {}.contiguous()'.format(param_var, param_var, param_var)
+                        # param_seq_str = '{}.is_contiguous() ? {} : {}.contiguous()'.format(param_var, param_var, param_var)
+                        None
                 param_seq_str_vec.append(param_seq_str)
             code += '      if (dbl::chk::dnnl_support_the_tensors(dnnl_input_tensors))\n'
             code += '        return AtenIpexCPUDev::dil_{}({});\n'.format(fname, ', '.join(param_seq_str_vec))

--- a/tests/cpu/test_torch.py
+++ b/tests/cpu/test_torch.py
@@ -12785,12 +12785,8 @@ class TestTorchDeviceType(TestCase):
         clone = transformation_fn(xc)
 
         if default_is_preserve:
-            if ipex.get_auto_dnnl():
-                self.assertTrue(clone.is_contiguous())
-                self.assertFalse(clone.is_contiguous(memory_format=memory_format))
-            else:
-                self.assertFalse(clone.is_contiguous())
-                self.assertTrue(clone.is_contiguous(memory_format=memory_format))
+            self.assertFalse(clone.is_contiguous())
+            self.assertTrue(clone.is_contiguous(memory_format=memory_format))
         else:
             self.assertTrue(clone.is_contiguous())
             self.assertFalse(clone.is_contiguous(memory_format=memory_format))

--- a/torch_ipex/csrc/cpu/dbl/DNNLChecker.cpp
+++ b/torch_ipex/csrc/cpu/dbl/DNNLChecker.cpp
@@ -56,7 +56,7 @@ bool dnnl_support_the_dimension_of(const std::vector<at::Tensor> &tensor_vec) {
 
 bool dnnl_tensor_has_data(const std::vector<at::Tensor> &tensor_vec) {
   for (auto it = tensor_vec.begin(); it != tensor_vec.end(); ++it)
-    if (it->data_ptr() == nullptr)
+    if (it->numel() == 0)
       return false;
 
   return true;

--- a/torch_ipex/csrc/cpu/dil/dil/tensor.hpp
+++ b/torch_ipex/csrc/cpu/dil/dil/tensor.hpp
@@ -449,6 +449,12 @@ class tensor : public memory {
     init(adims, adata_type, ahandle, aengine);
   }
 
+  // no format_tb, strides, buffer
+  tensor(const dims &adims, data_type adata_type, const dims &astrides,
+         void *ahandle, const engine &aengine = engine::cpu_engine()) {
+    init(adims, adata_type, astrides, ahandle, aengine);
+  }
+
   // no format_tag, no buffer
   tensor(const dims &adims, data_type adata_type,
          const engine &aengine = engine::cpu_engine()) {
@@ -478,6 +484,11 @@ class tensor : public memory {
   void init(const dims &adims, data_type adata_type, format_tag aformat_tag,
               void *ahandle, const engine &aengine = engine::cpu_engine()) {
     init({adims, adata_type, aformat_tag}, ahandle, aengine);
+  }
+
+  void init(const dims &adims, data_type adata_type, const dims &astrides,
+              void *ahandle, const engine &aengine = engine::cpu_engine()) {
+    init({adims, adata_type, astrides}, ahandle, aengine);
   }
 
   // format_tag, no buffer


### PR DESCRIPTION
@pinzhenx @hongzhen1 @jiayisunx @XiaobingSuper , Please review the patch to make sure the shape of aten tensor and its dil tensor buffer is consistent. The dil tensor is just a buffer of aten tensor, all shape info for the computation should come from the aten tensor. 

@pinzhenx , I'm not sure which DNNL OP requires its input tensors should be contiguous. Could you help to check it?

After that, each DNNL op needs to do "contiguous" explicitly if it requires its input tensors are contiguous.

