### PR TITLE
Refine unit test case and write the shape meta info back to aten tensor when the tensor is reordered to public format

### DIFF
--- a/scripts/cpu/gen-dense-cpu-ops.py
+++ b/scripts/cpu/gen-dense-cpu-ops.py
@@ -315,6 +315,9 @@ class DenseOPCodeGen(object):
         code += '    }\n'
 
         code += '  } catch (std::exception& e) {\n'
+        code += '#if defined(_DEBUG)\n'
+        code += '    TORCH_WARN(e.what());\n'
+        code += '#endif\n'
         code += '  }\n\n'
 
 

--- a/scripts/cpu/gen-dense-cpu-ops.py
+++ b/scripts/cpu/gen-dense-cpu-ops.py
@@ -306,8 +306,7 @@ class DenseOPCodeGen(object):
                     if param_var == 'out' and is_out_func(fname):
                         code += '      TORCH_INTERNAL_ASSERT({}.is_contiguous());\n'.format(param_var)
                     else:
-                        # param_seq_str = '{}.is_contiguous() ? {} : {}.contiguous()'.format(param_var, param_var, param_var)
-                        None
+                        param_seq_str = '{}.is_contiguous() ? {} : {}.contiguous()'.format(param_var, param_var, param_var)
                 param_seq_str_vec.append(param_seq_str)
             code += '      if (dbl::chk::dnnl_support_the_tensors(dnnl_input_tensors))\n'
             code += '        return AtenIpexCPUDev::dil_{}({});\n'.format(fname, ', '.join(param_seq_str_vec))

--- a/tests/cpu/test_lazy_reorder.py
+++ b/tests/cpu/test_lazy_reorder.py
@@ -756,12 +756,18 @@ class TestTensorShape(TestCase):
 
         x_cpu = torch.randn(old_shape)
         x_dpcpp = x_cpu.to(device=device).clone()
-        print(x_dpcpp.size())
+        self.assertTrue(ipex.is_dil_tensor(x_dpcpp))
+        self.assertEqual(ipex.get_dil_tensor_sizes(x_dpcpp), [4, 16])
+        self.assertEqual(ipex.is_dil_tensor_strides(x_dpcpp), [16, 1])
 
         x_cpu_view = x_cpu.view(new_shape)
-        print(x_cpu_view.size())
+        self.assertEqual(x_cpu_view.size(), [1, 4, 4, 4])
+        self.assertEqual(x_cpu_view.stride(), [64, 16, 4, 1])
+
         x_dpcpp_view = x_dpcpp.view(new_shape)
-        print(x_dpcpp_view.size())
+        self.assertTrue(ipex.is_dil_tensor(x_dpcpp_view))
+        self.assertEqual(ipex.get_dil_tensor_sizes(x_dpcpp_view), [1, 4, 4, 4])
+        self.assertEqual(ipex.is_dil_tensor_strides(x_dpcpp_view), [64, 16, 4, 1])
         
         y = torch.randn(new_shape)
         out_cpu = x_cpu_view * y

--- a/torch_ipex/csrc/aten_ipex_bridge.cpp
+++ b/torch_ipex/csrc/aten_ipex_bridge.cpp
@@ -75,7 +75,6 @@ void reorderDilTensorToPublic(const at::Tensor& ipexTensor) {
     TORCH_INTERNAL_ASSERT(shade_data_context->cpu_raw_data == shade_data_context->dil_tensor.get_data_handle());
     TORCH_INTERNAL_ASSERT(shade_data_context->cpu_raw_data != nullptr);
     TORCH_INTERNAL_ASSERT(shade_data_context->cpu_del_fun != nullptr);
-    TORCH_INTERNAL_ASSERT(check_aten_dil_shape_info(ipexTensor, dil_tensor));
 #endif
   } else {
 #if defined(_DEBUG)

--- a/torch_ipex/csrc/cpu/DevOPs.cpp
+++ b/torch_ipex/csrc/cpu/DevOPs.cpp
@@ -30,7 +30,6 @@ namespace cpu {
 
 #define CHECK_DNNL_OP_PRE_COND(tensor)                                    \
   TORCH_INTERNAL_ASSERT(tensor.defined());                                \
-  TORCH_INTERNAL_ASSERT(tensor.is_contiguous());                          \
   TORCH_INTERNAL_ASSERT(tensor.layout() == c10::kStrided)
 
 at::Tensor AtenIpexCPUDev::dil_convolution(

--- a/torch_ipex/csrc/cpu/DevOPs.cpp
+++ b/torch_ipex/csrc/cpu/DevOPs.cpp
@@ -30,6 +30,7 @@ namespace cpu {
 
 #define CHECK_DNNL_OP_PRE_COND(tensor)                                    \
   TORCH_INTERNAL_ASSERT(tensor.defined());                                \
+  TORCH_INTERNAL_ASSERT(tensor.is_contiguous());                          \
   TORCH_INTERNAL_ASSERT(tensor.layout() == c10::kStrided)
 
 at::Tensor AtenIpexCPUDev::dil_convolution(

--- a/torch_ipex/csrc/cpu/ShadeDataContext.h
+++ b/torch_ipex/csrc/cpu/ShadeDataContext.h
@@ -90,9 +90,6 @@ struct ShadeDataContext {
     TORCH_INTERNAL_ASSERT((data_type == SHADE_DATA_TYPE::CPU_RAW) || (data_type == SHADE_DATA_TYPE::DIL));
 
     if (data_type == SHADE_DATA_TYPE::DIL) {
-#if defined(_DEBUG)
-      TORCH_WARN(tensor.is_contiguous());
-#endif
       auto raw_cpu_data = tensor.storage().data_ptr().get();
       if (raw_cpu_data == nullptr) {
         // the dnnl tensor does not share data with raw tensor data.

--- a/torch_ipex/csrc/cpu/dbl/Common.cpp
+++ b/torch_ipex/csrc/cpu/dbl/Common.cpp
@@ -37,7 +37,7 @@ at::Tensor dil_tensor_to_dense(const at::Tensor& tensor) {
 dil::tensor try_gen_dil_tensor(const at::Tensor &input) {
   if (cpu::ShadeDataContext::isDilTensor(input)) {
     auto dil_tensor = cpu::ShadeDataContext::getDilTensor(input);
-    if (dil_tensor.is_public_format()) {
+    if ((!check_aten_dil_shape_info(input, dil_tensor)) && dil_tensor.is_public_format()) {
       dil_tensor.set_dims_and_strides(input.sizes().vec(), input.strides().vec());
     }
     return dil_tensor;

--- a/torch_ipex/csrc/cpu/dbl/Common.cpp
+++ b/torch_ipex/csrc/cpu/dbl/Common.cpp
@@ -36,7 +36,12 @@ at::Tensor dil_tensor_to_dense(const at::Tensor& tensor) {
 
 dil::tensor try_gen_dil_tensor(const at::Tensor &input) {
   if (cpu::ShadeDataContext::isDilTensor(input)) {
-    return cpu::ShadeDataContext::getDilTensor(input);
+    auto dil_tensor = cpu::ShadeDataContext::getDilTensor(input);
+    if (!check_aten_dil_shape_info(input, dil_tensor)) {
+      //TODO(Eikan): Pinzhen will fix the issue here
+      TORCH_INTERNAL_ASSERT(false);
+    }
+    return dil_tensor;
   } else {
     return dil_tensor_from_dense(input);
   }

--- a/torch_ipex/csrc/init_python_bindings.cpp
+++ b/torch_ipex/csrc/init_python_bindings.cpp
@@ -12,6 +12,8 @@
 
 #include "aten_ipex_type.h"
 #include "auto_opt_config.h"
+#include "cpu/dil/dil.hpp"
+#include "cpu/ShadeDataContext.h"
 #include "cpu/ExtendOPs.h"
 #include "cpu/MlpOPs.h"
 
@@ -28,6 +30,28 @@ py::object GetRevisions() {
 void setAutoDNNL(bool val) {
   AutoOptConfig::singleton().set_auto_dnnl(val);
 }
+
+/// **** Only for unit test ****
+bool isDilTensor(const at::Tensor &tensor) {
+  return cpu::ShadeDataContext::isDilTensor(tensor);
+}
+
+dil::dims getDilTensorSizes(const at::Tensor &tensor) {
+  if (isDilTensor(tensor)) {
+    auto dil_tensor = cpu::ShadeDataContext::getDilTensor(tensor);
+    return dil_tensor.get_dims();
+  }
+  return dil::dims();
+}
+
+dil::dims getDilTensorStrides(const at::Tensor &tensor) {
+  if (isDilTensor(tensor)) {
+    auto dil_tensor = cpu::ShadeDataContext::getDilTensor(tensor);
+    return dil_tensor.get_strides();
+  }
+  return dil::dims();
+}
+/// ****************************
 
 void InitIpexModuleBindings(py::module m) {
   m.def("_initialize_aten_bindings",
@@ -97,6 +121,10 @@ void InitIpexModuleBindings(py::module m) {
   m.def("mlp_create_handle", &AtenIpexTypeMLPExt::create_handle);
   m.def("mlp_set_relu_mask", &AtenIpexTypeMLPExt::set_relu_mask);
   m.def("mlp_release_handle", &AtenIpexTypeMLPExt::release_handle);
+
+  m.def("is_dil_tensor", &isDilTensor);
+  m.def("get_dil_tensor_sizes", &getDilTensorSizes);
+  m.def("is_dil_tensor_strides", &getDilTensorStrides);
 }
 
 }  // namespace

--- a/torch_ipex/csrc/init_python_bindings.cpp
+++ b/torch_ipex/csrc/init_python_bindings.cpp
@@ -124,7 +124,7 @@ void InitIpexModuleBindings(py::module m) {
 
   m.def("is_dil_tensor", &isDilTensor);
   m.def("get_dil_tensor_sizes", &getDilTensorSizes);
-  m.def("is_dil_tensor_strides", &getDilTensorStrides);
+  m.def("get_dil_tensor_strides", &getDilTensorStrides);
 }
 
 }  // namespace

--- a/torch_ipex/csrc/utils.cpp
+++ b/torch_ipex/csrc/utils.cpp
@@ -127,4 +127,13 @@ bool check_tensor_own_shade_context(const at::Tensor& tensor) {
   return (data_ptr != data_ctx) && (data_ctx != nullptr);
 }
 
+bool check_aten_dil_shape_info(const at::Tensor& ipex_tensor, const dil::tensor &dil_tensor) {
+  if (dil_tensor.is_public_format()) {
+    return ipex_tensor.sizes().vec() == dil_tensor.get_dims() &&
+          ipex_tensor.strides().vec() == dil_tensor.get_strides();
+  } else {
+    return ipex_tensor.sizes().vec() == dil_tensor.get_dims();
+  }
+}
+
 } // namespace torch_ipex

--- a/torch_ipex/csrc/utils.h
+++ b/torch_ipex/csrc/utils.h
@@ -20,5 +20,6 @@ at::ScalarType get_at_data_type(dil::data_type);
 bool check_auto_dnnl();
 bool check_tensor_own_whole_storage(const at::Tensor& tensor);
 bool check_tensor_own_shade_context(const at::Tensor& tensor);
+bool check_aten_dil_shape_info(const at::Tensor& ipex_tensor, const dil::tensor &dil_tensor);
 
 } // namespace torch_ipex


### PR DESCRIPTION
1. Make sure all input tensors of DNNL OP are contiguous
2. Expose some DNNL interface to PyThon to check if a tensor is dil tensor for unit test
3. Fix the issue that didn't check if the tensor own whole storage
4. Write the shape meta info back to aten tensor if the tensor is reordered to public format