### PR TITLE
Lazy reorder for bf16

### DIFF
--- a/tests/cpu/common_ipex_conf.py
+++ b/tests/cpu/common_ipex_conf.py
@@ -1,0 +1,35 @@
+import intel_pytorch_extension as ipex
+
+class AutoMixPrecision(object):
+    def __init__(self, enable_or_not = False):
+        self.old_value = ipex.core.get_mix_bf16_fp32()
+        self.enable_or_not = enable_or_not
+
+    def __enter__(self):
+        if self.enable_or_not:
+            ipex.core.enable_mix_bf16_fp32()
+        else:
+            ipex.core.disable_mix_bf16_fp32()
+
+    def __exit__(self, *args, **kwargs):
+        if self.old_value:
+            ipex.core.enable_mix_bf16_fp32()
+        else:
+            ipex.core.disable_mix_bf16_fp32()
+
+class AutoDNNL(object):
+    def __init__(self, enable_or_not = False):
+        self.old_value = ipex.core.get_auto_dnnl()
+        self.enable_or_not = enable_or_not
+
+    def __enter__(self):
+        if self.enable_or_not:
+            ipex.core.enable_auto_dnnl()
+        else:
+            ipex.core.disable_auto_dnnl()
+
+    def __exit__(self, *args, **kwargs):
+        if self.old_value:
+            ipex.core.enable_auto_dnnl()
+        else:
+            ipex.core.disable_auto_dnnl()

--- a/tests/cpu/test_bf16_lazy_reorder.py
+++ b/tests/cpu/test_bf16_lazy_reorder.py
@@ -511,13 +511,19 @@ class TestLinearAlgebraOps(TestCase):
             for j in range(8, 12, 2):
                 alpha = i / 10
                 beta = j / 10
-                num_batches = 2
+                batches = 2
 
-                x_auto_mix_a, x_auto_mix_b, add_auto_mix, x_man_bf16_a, x_man_bf16_b, add_man_bf16 = self._gen_mm_tensor(rand_seed, num_batches)
+                M, N, O = 23, 8, 12
+                x_auto_mix_a = torch.randn(batches, M, N, dtype=torch.float32, device=device)
+                x_auto_mix_b = torch.randn(batches, N, O, dtype=torch.float32, device=device)
+                add_auto_mix = torch.randn(batches, M, O, dtype=torch.float32, device=device)
+
+                x_man_bf16_a = x_auto_mix_a.to(torch.bfloat16)
+                x_man_bf16_b = x_auto_mix_b.to(torch.bfloat16)
+                add_man_bf16 = add_auto_mix.to(torch.bfloat16)
 
                 with AutoDNNL(True), AutoMixPrecision(False):
                     res_man_bf16 = torch.baddbmm(add_man_bf16, x_man_bf16_a, x_man_bf16_b, beta=beta, alpha=alpha)
-
                     with AutoMixPrecision(True):
                         res_auto_mix = torch.baddbmm(add_auto_mix, x_auto_mix_a, x_auto_mix_b, beta=beta, alpha=alpha)
                         self.assertEqual(res_auto_mix.dtype, torch.float)

--- a/tests/cpu/test_bf16_lazy_reorder.py
+++ b/tests/cpu/test_bf16_lazy_reorder.py
@@ -165,5 +165,365 @@ class TestRelu(TestCase):
                 zero_base = torch.zeros_like(res)
                 self.assertEqual(res, zero_base, 1e-2)
 
+class TestBinOPs(TestCase):
+    def _gen_shapes(self):
+        dims = torch.randint(1, 10, (1,))
+        shape = torch.randint(1, 10, list(dims))
+        return shape.tolist()
+
+    # def test_add(self):
+    #     rand_seed = int(get_rand_seed())
+    #     print("{} rand sed: {}".format(sys._getframe().f_code.co_name, rand_seed))
+    #     torch.manual_seed(1591058395950926848)
+
+    #     shape = self._gen_shapes()
+    #     x_auto_mix_a = torch.rand(shape, dtype=torch.float32, device=device)
+    #     x_auto_mix_b = torch.rand(shape, dtype=torch.float32, device=device)
+    #     x_man_bf16_a = x_auto_mix_a.to(torch.bfloat16)
+    #     x_man_bf16_b = x_auto_mix_b.to(torch.bfloat16)
+
+    #     with AutoDNNL(True), AutoMixPrecision(False):
+    #         res_man_bf16 = x_man_bf16_a + x_man_bf16_b
+    #         self.assertEqual(res_man_bf16.dtype, torch.bfloat16)
+
+    #         with AutoMixPrecision(True):
+    #             self.assertEqual(x_auto_mix_a.dtype, torch.float)
+    #             self.assertFalse(ipex.core.is_bf16_dil_tensor(x_auto_mix_a))
+    #             self.assertEqual(x_auto_mix_b.dtype, torch.float)
+    #             self.assertFalse(ipex.core.is_bf16_dil_tensor(x_auto_mix_b))
+    #             res_auto_mix = x_auto_mix_a + x_auto_mix_b
+    #             self.assertEqual(res_auto_mix.dtype, torch.float)
+    #             self.assertTrue(ipex.core.is_bf16_dil_tensor(res_auto_mix))
+
+    def test_mul(self):
+        rand_seed = int(get_rand_seed())
+        print("{} rand sed: {}".format(sys._getframe().f_code.co_name, rand_seed))
+        torch.manual_seed(1591058395950926848)
+
+        shape = self._gen_shapes()
+        x_auto_mix_a = torch.rand(shape, dtype=torch.float32, device=device)
+        x_auto_mix_b = torch.rand(shape, dtype=torch.float32, device=device)
+        x_man_bf16_a = x_auto_mix_a.to(torch.bfloat16)
+        x_man_bf16_b = x_auto_mix_b.to(torch.bfloat16)
+
+        with AutoDNNL(True), AutoMixPrecision(False):
+            res_man_bf16 = x_man_bf16_a * x_man_bf16_b
+            self.assertEqual(res_man_bf16.dtype, torch.bfloat16)
+
+            with AutoMixPrecision(True):
+                self.assertEqual(x_auto_mix_a.dtype, torch.float)
+                self.assertFalse(ipex.core.is_bf16_dil_tensor(x_auto_mix_a))
+                self.assertEqual(x_auto_mix_b.dtype, torch.float)
+                self.assertFalse(ipex.core.is_bf16_dil_tensor(x_auto_mix_b))
+                res_auto_mix = x_auto_mix_a * x_auto_mix_b
+                self.assertEqual(res_auto_mix.dtype, torch.float)
+                self.assertTrue(ipex.core.is_bf16_dil_tensor(res_auto_mix))
+                self.assertEqual(res_auto_mix, res_man_bf16.float())
+
+    def test_mul_(self):
+        rand_seed = int(get_rand_seed())
+        print("{} rand sed: {}".format(sys._getframe().f_code.co_name, rand_seed))
+        torch.manual_seed(1591058395950926848)
+
+        shape = self._gen_shapes()
+        x_auto_mix_a = torch.rand(shape, dtype=torch.float32, device=device)
+        x_auto_mix_b = torch.rand(shape, dtype=torch.float32, device=device)
+        x_man_bf16_a = x_auto_mix_a.to(torch.bfloat16)
+        x_man_bf16_b = x_auto_mix_b.to(torch.bfloat16)
+
+        with AutoDNNL(True), AutoMixPrecision(False):
+            res_man_bf16 = x_man_bf16_a * x_man_bf16_b
+            self.assertEqual(res_man_bf16.dtype, torch.bfloat16)
+            x_man_bf16_a *= x_man_bf16_b
+            self.assertEqual(x_man_bf16_a.dtype, torch.bfloat16)
+            self.assertEqual(x_man_bf16_a.float(), res_man_bf16.float())
+
+            with AutoMixPrecision(True):
+                self.assertEqual(x_auto_mix_a.dtype, torch.float)
+                self.assertFalse(ipex.core.is_bf16_dil_tensor(x_auto_mix_a))
+                self.assertEqual(x_auto_mix_b.dtype, torch.float)
+                self.assertFalse(ipex.core.is_bf16_dil_tensor(x_auto_mix_b))
+                x_auto_mix_a *= x_auto_mix_b
+                self.assertEqual(x_auto_mix_a.dtype, torch.float)
+                self.assertTrue(ipex.core.is_bf16_dil_tensor(x_auto_mix_a))
+                self.assertEqual(x_auto_mix_a, x_man_bf16_a.float())
+
+# class TestLinear(TestCase):
+#     def test_linear(self):
+#         rand_seed = int(get_rand_seed())
+#         print("{} rand sed: {}".format(sys._getframe().f_code.co_name, rand_seed))
+#         torch.manual_seed(rand_seed)
+#         in_features = torch.randint(3, 10, (1,)).item()
+#         out_features = torch.randint(3, 100, (1,)).item()
+#         x_auto_mix = torch.randn(3, in_features, dtype=torch.float32, device=device) * 10
+#         x_man_bf16 = x_auto_mix.to(torch.bfloat16)
+
+#         for bias in [True, False]:
+#             linear = torch.nn.Linear(in_features, out_features, bias=bias)
+
+#             linear_auto_mix = copy.deepcopy(linear).to(device=device)
+#             linear_man_bf16 = copy.deepcopy(linear).to(device=device).to(torch.bfloat16)
+
+#             with AutoDNNL(True), AutoMixPrecision(False):
+#                 res_man_bf16 = linear_man_bf16(x_man_bf16)
+#                 self.assertEqual(res_man_bf16.dtype, torch.bfloat16)
+
+#                 with AutoMixPrecision(True):
+#                     res_auto_mix = linear_auto_mix(x_auto_mix)
+#                     self.assertEqual(res_auto_mix.dtype, torch.float)
+#                     self.assertTrue(ipex.core.is_bf16_dil_tensor(res_auto_mix))
+#                     self.assertEqual(res_auto_mix, res_man_bf16.float())
+
+class TestPool(TestCase):
+    def test_avg_pool2d(self):
+        rand_seed = int(get_rand_seed())
+        print("{} rand sed: {}".format(sys._getframe().f_code.co_name, rand_seed))
+        torch.manual_seed(rand_seed)
+        N = torch.randint(3, 10, (1,)).item()
+        C = torch.randint(3, 10, (1,)).item()
+
+        x_auto_mix = torch.randn(N, C, 64, 64, dtype=torch.float32, device=device) * 10
+        x_man_bf16 = x_auto_mix.to(torch.bfloat16)
+
+        for count_include_pad in [True, False]:
+            avg_pool2d = torch.nn.AvgPool2d(
+                kernel_size=3,
+                stride=2,
+                padding=1,
+                count_include_pad=count_include_pad)
+
+            avg_pool2d_auto_mix = copy.deepcopy(avg_pool2d).to(device=device)
+            avg_pool2d_man_bf16 = copy.deepcopy(avg_pool2d).to(device=device).to(torch.bfloat16)
+
+            with AutoDNNL(True), AutoMixPrecision(False):
+                res_man_bf16 = avg_pool2d_man_bf16(x_man_bf16)
+                self.assertEqual(res_man_bf16.dtype, torch.bfloat16)
+
+                with AutoMixPrecision(True):
+                    res_auto_mix = avg_pool2d_auto_mix(x_auto_mix)
+                    self.assertEqual(res_auto_mix.dtype, torch.float)
+                    self.assertTrue(ipex.core.is_bf16_dil_tensor(res_auto_mix))
+                    self.assertEqual(res_auto_mix, res_man_bf16.float())
+
+    def test_avg_pool3d(self):
+        rand_seed = int(get_rand_seed())
+        print("{} rand sed: {}".format(sys._getframe().f_code.co_name, rand_seed))
+        torch.manual_seed(rand_seed)
+        N = torch.randint(3, 10, (1,)).item()
+        C = torch.randint(3, 10, (1,)).item()
+
+        x_auto_mix = torch.randn(N, C, 64, 64, 64, dtype=torch.float32, device=device) * 10
+        x_man_bf16 = x_auto_mix.to(torch.bfloat16)
+
+        for count_include_pad in [True, False]:
+            avg_pool3d = torch.nn.AvgPool3d(
+                kernel_size=3,
+                stride=2,
+                padding=1,
+                count_include_pad=count_include_pad)
+
+            avg_pool3d_auto_mix = copy.deepcopy(avg_pool3d).to(device=device)
+            avg_pool3d_man_bf16 = copy.deepcopy(avg_pool3d).to(device=device).to(torch.bfloat16)
+
+            with AutoDNNL(True), AutoMixPrecision(False):
+                res_man_bf16 = avg_pool3d_man_bf16(x_man_bf16)
+                self.assertEqual(res_man_bf16.dtype, torch.bfloat16)
+
+                with AutoMixPrecision(True):
+                    res_auto_mix = avg_pool3d_auto_mix(x_auto_mix)
+                    self.assertEqual(res_auto_mix.dtype, torch.float)
+                    self.assertTrue(ipex.core.is_bf16_dil_tensor(res_auto_mix))
+                    self.assertEqual(res_auto_mix, res_man_bf16.float())
+
+class TestSoftMax(TestCase):
+    def test_softmax(self):
+        rand_seed = int(get_rand_seed())
+        print("{} rand sed: {}".format(sys._getframe().f_code.co_name, rand_seed))
+        torch.manual_seed(rand_seed)
+        x_auto_mix = torch.randn(3, 4, 5, dtype=torch.float32, device=device) * 10
+        x_man_bf16 = x_auto_mix.to(torch.bfloat16)
+
+        for dim in range(x_auto_mix.ndim):
+            softmax = torch.nn.Softmax(dim=dim)
+
+            softmax_auto_mix = copy.deepcopy(softmax).to(device=device)
+            softmax_man_bf16 = copy.deepcopy(softmax).to(device=device).to(torch.bfloat16)
+
+            with AutoDNNL(True), AutoMixPrecision(False):
+                res_man_bf16 = softmax_man_bf16(x_man_bf16)
+                self.assertEqual(res_man_bf16.dtype, torch.bfloat16)
+
+                with AutoMixPrecision(True):
+                    res_auto_mix = softmax_auto_mix(x_auto_mix)
+                    self.assertEqual(res_auto_mix.dtype, torch.float)
+                    self.assertTrue(ipex.core.is_bf16_dil_tensor(res_auto_mix))
+                    self.assertEqual(res_auto_mix, res_man_bf16.float())
+
+class TestSigmoid(TestCase):
+    def test_sigmoid(self):
+        rand_seed = int(get_rand_seed())
+        print("{} rand sed: {}".format(sys._getframe().f_code.co_name, rand_seed))
+        torch.manual_seed(rand_seed)
+        x_auto_mix = torch.randn(4, 5, dtype=torch.float32, device=device) * 10
+        x_man_bf16 = x_auto_mix.to(torch.bfloat16)
+
+        with AutoDNNL(True), AutoMixPrecision(False):
+            res_man_bf16 = torch.sigmoid(x_man_bf16)
+            self.assertEqual(res_man_bf16.dtype, torch.bfloat16)
+            with AutoMixPrecision(True):
+                res_auto_mix = torch.sigmoid(x_auto_mix)
+                self.assertEqual(res_auto_mix.dtype, torch.float)
+                self.assertTrue(ipex.core.is_bf16_dil_tensor(res_auto_mix))
+                self.assertEqual(res_auto_mix, res_man_bf16.float())
+
+    def test_sigmoid_(self):
+        rand_seed = int(get_rand_seed())
+        print("{} rand sed: {}".format(sys._getframe().f_code.co_name, rand_seed))
+        torch.manual_seed(rand_seed)
+        x_auto_mix = torch.randn(4, 5, dtype=torch.float32, device=device) * 10
+        x_man_bf16 = x_auto_mix.to(torch.bfloat16)
+
+        with AutoDNNL(True), AutoMixPrecision(False):
+            torch.sigmoid_(x_man_bf16)
+            with AutoMixPrecision(True):
+                torch.sigmoid_(x_auto_mix)
+                self.assertEqual(x_auto_mix.dtype, torch.float)
+                self.assertTrue(ipex.core.is_bf16_dil_tensor(x_auto_mix))
+                self.assertEqual(x_auto_mix, x_man_bf16.float())
+
+class TestLinearAlgebraOps(TestCase):
+    def _gen_mm_tensor(self, seed, batches = None):
+        torch.manual_seed(seed)
+        M, N, O = 23, 8, 12
+        M, N, O = 3, 2, 3
+        if batches != None:
+            x_auto_mix_a = torch.randn(batches, M, N, dtype=torch.float32, device=device)
+            x_auto_mix_b = torch.randn(batches, N, O, dtype=torch.float32, device=device)
+        else:
+            x_auto_mix_a = torch.randn(M, N, dtype=torch.float32, device=device)
+            x_auto_mix_b = torch.randn(N, O, dtype=torch.float32, device=device)
+        res_auto_mix = torch.randn(M, O, dtype=torch.float32, device=device)
+        x_man_bf16_a = x_auto_mix_a.to(torch.bfloat16)
+        x_man_bf16_b = x_auto_mix_b.to(torch.bfloat16)
+        res_man_bf16 = res_auto_mix.to(torch.bfloat16)
+
+        return x_auto_mix_a, x_auto_mix_b, res_auto_mix, x_man_bf16_a, x_man_bf16_b, res_man_bf16
+
+    def test_mm(self):
+        rand_seed = int(get_rand_seed())
+        print("{} rand sed: {}".format(sys._getframe().f_code.co_name, rand_seed))
+        x_auto_mix_a, x_auto_mix_b, _, x_man_bf16_a, x_man_bf16_b, _ = self._gen_mm_tensor(rand_seed)
+
+        with AutoDNNL(True), AutoMixPrecision(False):
+            res_man_bf16 = torch.mm(x_man_bf16_a, x_man_bf16_b)
+            self.assertEqual(res_man_bf16.dtype, torch.bfloat16)
+            with AutoMixPrecision(True):
+                res_auto_mix = torch.mm(x_auto_mix_a, x_auto_mix_b)
+                self.assertEqual(res_auto_mix.dtype, torch.float)
+                self.assertTrue(ipex.core.is_bf16_dil_tensor(res_auto_mix))
+                self.assertEqual(res_auto_mix, res_man_bf16.float())
+
+    def test_mm_out(self):
+        rand_seed = int(get_rand_seed())
+        print("{} rand sed: {}".format(sys._getframe().f_code.co_name, rand_seed))
+        x_auto_mix_a, x_auto_mix_b, res_auto_mix, x_man_bf16_a, x_man_bf16_b, res_man_bf16 = self._gen_mm_tensor(rand_seed)
+
+        with AutoDNNL(True), AutoMixPrecision(False):
+            torch.mm(x_man_bf16_a, x_man_bf16_b, out=res_man_bf16)
+            self.assertEqual(res_man_bf16.dtype, torch.bfloat16)
+            with AutoMixPrecision(True):
+                torch.mm(x_auto_mix_a, x_auto_mix_b, out=res_auto_mix)
+                self.assertEqual(res_auto_mix.dtype, torch.float)
+                self.assertTrue(ipex.core.is_bf16_dil_tensor(res_auto_mix))
+                self.assertEqual(res_auto_mix, res_man_bf16.float())
+
+    def test_bmm(self):
+        rand_seed = int(get_rand_seed())
+        print("{} rand sed: {}".format(sys._getframe().f_code.co_name, rand_seed))
+        x_auto_mix_a, x_auto_mix_b, _, x_man_bf16_a, x_man_bf16_b, _ = self._gen_mm_tensor(rand_seed)
+
+        with AutoDNNL(True), AutoMixPrecision(False):
+            res_man_bf16 = torch.bmm(x_man_bf16_a, x_man_bf16_b)
+            self.assertEqual(res_man_bf16.dtype, torch.bfloat16)
+            with AutoMixPrecision(True):
+                res_auto_mix = torch.bmm(x_auto_mix_a, x_auto_mix_b)
+                self.assertEqual(res_auto_mix.dtype, torch.float)
+                self.assertTrue(ipex.core.is_bf16_dil_tensor(res_auto_mix))
+                self.assertEqual(res_auto_mix, res_man_bf16.float())
+
+    def test_bmm_out(self):
+        rand_seed = int(get_rand_seed())
+        print("{} rand sed: {}".format(sys._getframe().f_code.co_name, rand_seed))
+        x_auto_mix_a, x_auto_mix_b, res_auto_mix, x_man_bf16_a, x_man_bf16_b, res_man_bf16 = self._gen_mm_tensor(rand_seed)
+
+        with AutoDNNL(True), AutoMixPrecision(False):
+            torch.bmm(x_man_bf16_a, x_man_bf16_b, out=res_man_bf16)
+            self.assertEqual(res_man_bf16.dtype, torch.bfloat16)
+            with AutoMixPrecision(True):
+                torch.bmm(x_auto_mix_a, x_auto_mix_b, out=res_auto_mix)
+                self.assertEqual(res_auto_mix.dtype, torch.float)
+                self.assertTrue(ipex.core.is_bf16_dil_tensor(res_auto_mix))
+                self.assertEqual(res_auto_mix, res_man_bf16.float())
+
+    def test_addmm(self):
+        rand_seed = int(get_rand_seed())
+        print("{} rand sed: {}".format(sys._getframe().f_code.co_name, rand_seed))
+        torch.manual_seed(rand_seed)
+        for i in range(8, 12, 2):
+            for j in range(8, 12, 2):
+                alpha = i / 10
+                beta = j / 10
+
+                x_auto_mix_a, x_auto_mix_b, add_auto_mix, x_man_bf16_a, x_man_bf16_b, add_man_bf16 = self._gen_mm_tensor(rand_seed)
+
+                with AutoDNNL(True), AutoMixPrecision(False):
+                    res_man_bf16 = torch.addmm(input=add_man_bf16, mat1=x_man_bf16_a, mat2=x_man_bf16_b, alpha=alpha, beta=beta)
+                    self.assertEqual(res_man_bf16.dtype, torch.bfloat16)
+                    with AutoMixPrecision(True):
+                        res_auto_mix = torch.addmm(input=add_auto_mix, mat1=x_auto_mix_a, mat2=x_auto_mix_b, alpha=alpha, beta=beta)
+                        self.assertEqual(res_auto_mix.dtype, torch.float)
+                        self.assertTrue(ipex.core.is_bf16_dil_tensor(res_auto_mix))
+                        self.assertEqual(res_auto_mix, res_man_bf16.float())
+
+    def test_addbmm(self):
+        rand_seed = int(get_rand_seed())
+        print("{} rand sed: {}".format(sys._getframe().f_code.co_name, rand_seed))
+        torch.manual_seed(rand_seed)
+        for i in range(8, 12, 2):
+            for j in range(8, 12, 2):
+                alpha = i / 10
+                beta = j / 10
+                num_batches = 10
+                x_auto_mix_a, x_auto_mix_b, add_auto_mix, x_man_bf16_a, x_man_bf16_b, add_man_bf16 = self._gen_mm_tensor(rand_seed, num_batches)
+                with AutoDNNL(True), AutoMixPrecision(False):
+                    res_man_bf16 = torch.addbmm(add_man_bf16, x_man_bf16_a, x_man_bf16_b, beta=beta, alpha=alpha)
+                    self.assertEqual(res_man_bf16.dtype, torch.bfloat16)
+                    with AutoMixPrecision(True):
+                        res_auto_mix = torch.addbmm(add_auto_mix, x_auto_mix_a, x_auto_mix_b, beta=beta, alpha=alpha)
+                        self.assertEqual(res_auto_mix.dtype, torch.float)
+                        self.assertTrue(ipex.core.is_bf16_dil_tensor(res_auto_mix))
+                        self.assertEqual(res_auto_mix, res_man_bf16.float())
+
+    def test_baddbmm(self):
+        rand_seed = int(get_rand_seed())
+        print("{} rand sed: {}".format(sys._getframe().f_code.co_name, rand_seed))
+        torch.manual_seed(rand_seed)
+        for i in range(8, 12, 2):
+            for j in range(8, 12, 2):
+                alpha = i / 10
+                beta = j / 10
+                num_batches = 2
+
+                x_auto_mix_a, x_auto_mix_b, add_auto_mix, x_man_bf16_a, x_man_bf16_b, add_man_bf16 = self._gen_mm_tensor(rand_seed, num_batches)
+
+                with AutoDNNL(True), AutoMixPrecision(False):
+                    res_man_bf16 = torch.baddbmm(add_man_bf16, x_man_bf16_a, x_man_bf16_b, beta=beta, alpha=alpha)
+
+                    with AutoMixPrecision(True):
+                        res_auto_mix = torch.baddbmm(add_auto_mix, x_auto_mix_a, x_auto_mix_b, beta=beta, alpha=alpha)
+                        self.assertEqual(res_auto_mix.dtype, torch.float)
+                        self.assertTrue(ipex.core.is_bf16_dil_tensor(res_auto_mix))
+                        self.assertEqual(res_auto_mix, res_man_bf16.float())
+
 if __name__ == '__main__':
     test = unittest.main()

--- a/tests/cpu/test_bf16_lazy_reorder.py
+++ b/tests/cpu/test_bf16_lazy_reorder.py
@@ -1,0 +1,169 @@
+"""Tests for lazy reorder."""
+from __future__ import division
+from __future__ import print_function
+
+import os
+import math
+import time
+import random
+import unittest
+from functools import reduce
+import copy
+import sys
+import torch
+import intel_pytorch_extension as ipex
+
+import torch.nn as nn
+import torch.backends.cudnn as cudnn
+from torch.nn import Parameter
+import torch.nn.functional as F
+from torch.autograd import gradcheck
+from torch.autograd.gradcheck import gradgradcheck
+from torch._six import inf, nan
+
+from common_utils import TestCase, iter_indices, TEST_NUMPY, TEST_SCIPY, TEST_MKL, \
+    TEST_LIBROSA, run_tests, download_file, skipIfNoLapack, suppress_warnings, \
+    IS_WINDOWS, PY3, NO_MULTIPROCESSING_SPAWN, do_test_dtypes, do_test_empty_full, \
+    IS_SANDCASTLE, load_tests, brute_pdist, brute_cdist, slowTest, \
+    skipCUDANonDefaultStreamIf, skipCUDAMemoryLeakCheckIf
+
+from common_ipex_conf import AutoMixPrecision, AutoDNNL
+
+def get_rand_seed():
+    return int(time.time() * 1000000000)
+
+device = torch.device("dpcpp:0")
+class TestConv(TestCase):
+    def test_Conv2d_with_cpu(self):
+        rand_seed = int(get_rand_seed())
+        print("{} rand sed: {}".format(sys._getframe().f_code.co_name, rand_seed))
+        torch.manual_seed(rand_seed)
+
+        _conv = torch.nn.Conv2d(1, 1, (3, 3))
+
+        bn_man_bf16 =copy.deepcopy(_conv).to(device=device).to(torch.bfloat16)
+        bn_auto_mix =copy.deepcopy(_conv).to(device=device)
+
+        _in_cpu = torch.rand((1, 1, 7, 7))
+        in_auto_mix = _in_cpu.to(device=device)
+        in_man_bf16 = in_auto_mix.to(torch.bfloat16)
+
+        res_cpu_fp32 = _conv(_in_cpu)
+
+        with AutoDNNL(True), AutoMixPrecision(False):
+            res_man_bf16 = bn_man_bf16(in_man_bf16)
+            self.assertEqual(res_man_bf16.dtype, torch.bfloat16)
+            self.assertEqual(res_cpu_fp32.bfloat16().float(), res_man_bf16, 1e-2)
+
+            with AutoMixPrecision(True):
+                self.assertEqual(in_auto_mix.dtype, torch.float)
+                self.assertFalse(ipex.core.is_bf16_dil_tensor(in_auto_mix))
+                res_auto_bf16 = bn_auto_mix(in_auto_mix)
+                self.assertTrue(ipex.core.is_bf16_dil_tensor(res_auto_bf16))
+                self.assertEqual(res_man_bf16.float(), res_auto_bf16.float(), 1e-2)
+
+class TestBatchNorm(TestCase):
+    def test_batch_norm2d(self):
+        rand_seed = int(get_rand_seed())
+        print("{} rand sed: {}".format(sys._getframe().f_code.co_name, rand_seed))
+        torch.manual_seed(rand_seed)
+
+        x_auto_mix = torch.randn(64, 3, 35, 45, dtype=torch.float32, device=device) * 10
+        x_man_bf16 = x_auto_mix.to(torch.bfloat16)
+
+        _bn = torch.nn.BatchNorm2d(3)
+        bn_man_bf16 =copy.deepcopy(_bn).to(device=device)
+        bn_auto_mix =copy.deepcopy(_bn).to(device=device)
+
+        with AutoDNNL(True), AutoMixPrecision(False):
+            res_bf16 = bn_man_bf16(x_man_bf16)
+            self.assertEqual(res_bf16.dtype, torch.bfloat16)
+
+            with AutoMixPrecision(True):
+                ipex.core.enable_mix_bf16_fp32()
+                self.assertEqual(x_auto_mix.dtype, torch.float)
+                self.assertFalse(ipex.core.is_bf16_dil_tensor(x_auto_mix))
+                res_auto_mix = bn_auto_mix(x_auto_mix)
+                self.assertEqual(res_auto_mix.dtype, torch.float)
+                self.assertEqual(x_auto_mix.dtype, torch.float)
+                self.assertTrue(ipex.core.is_bf16_dil_tensor(res_auto_mix))
+                self.assertTrue(ipex.core.is_bf16_dil_tensor(x_auto_mix))
+
+                self.assertEqual(res_bf16.float(), res_auto_mix)
+
+
+    def test_batch_norm3d(self):
+        rand_seed = int(get_rand_seed())
+        print("{} rand sed: {}".format(sys._getframe().f_code.co_name, rand_seed))
+        torch.manual_seed(rand_seed)
+        x_auto_mix = torch.randn(4, 3, 30, 30, 30, dtype=torch.float32, device=device) * 10
+        x_man_bf16 = x_auto_mix.to(torch.bfloat16)
+
+        _bn = torch.nn.BatchNorm3d(3)
+        bn_man_bf16 =copy.deepcopy(_bn).to(device=device)
+        bn_auto_mix =copy.deepcopy(_bn).to(device=device)
+
+        with AutoDNNL(True), AutoMixPrecision(False):
+            res_man_bf16 = bn_man_bf16(x_man_bf16)
+            self.assertEqual(x_man_bf16.dtype, torch.bfloat16)
+
+            with AutoMixPrecision(True):
+                ipex.core.enable_mix_bf16_fp32()
+                self.assertEqual(x_auto_mix.dtype, torch.float)
+                self.assertFalse(ipex.core.is_bf16_dil_tensor(x_auto_mix))
+                res_auto_mix = bn_auto_mix(x_auto_mix)
+                self.assertEqual(res_auto_mix.dtype, torch.float)
+                self.assertEqual(x_auto_mix.dtype, torch.float)
+                self.assertTrue(ipex.core.is_bf16_dil_tensor(res_auto_mix))
+                self.assertTrue(ipex.core.is_bf16_dil_tensor(x_auto_mix))
+
+                self.assertEqual(res_man_bf16.float(), res_auto_mix)
+
+class TestRelu(TestCase):
+    def test_relu(self):
+        rand_seed = int(get_rand_seed())
+        print("{} rand sed: {}".format(sys._getframe().f_code.co_name, rand_seed))
+        torch.manual_seed(rand_seed)
+        x_fp32 = torch.randn((4, 5), dtype=torch.float32, device=device) * 10
+        x_bf16 = x_fp32.to(torch.bfloat16)
+
+        res_fp32 = torch.relu(x_fp32)
+
+        with AutoDNNL(True), AutoMixPrecision(False):
+            res_man_bf16 = torch.relu(x_bf16)
+            self.assertEqual(res_fp32.bfloat16().float(), res_man_bf16)
+
+            with AutoMixPrecision(True):
+                res_auto_mix = torch.relu(x_fp32)
+                self.assertEqual(res_auto_mix.dtype, torch.float)
+                self.assertTrue(ipex.core.is_bf16_dil_tensor(res_auto_mix))
+
+                res = (res_auto_mix - res_man_bf16.float()) / res_auto_mix
+                res[torch.isnan(res)] = 0
+                zero_base = torch.zeros_like(res)
+                self.assertEqual(res, zero_base, 1e-2)
+
+    def test_relu_(self):
+        rand_seed = int(get_rand_seed())
+        print("{} rand sed: {}".format(sys._getframe().f_code.co_name, rand_seed))
+        torch.manual_seed(rand_seed)
+
+        x_fp32 = torch.randn((4, 5), dtype=torch.float32, device=device) * 10
+        x_bf16 = x_fp32.to(torch.bfloat16)
+
+        with AutoDNNL(True), AutoMixPrecision(False):
+            x_bf16.relu_()
+            self.assertEqual(x_bf16.dtype, torch.bfloat16)
+
+            with AutoMixPrecision(True):
+                x_fp32.relu_()
+                self.assertEqual(x_fp32.dtype, torch.float)
+                self.assertTrue(ipex.core.is_bf16_dil_tensor(x_fp32))
+
+                res = (x_fp32 - x_bf16.float()) / x_fp32
+                res[torch.isnan(res)] = 0
+                zero_base = torch.zeros_like(res)
+                self.assertEqual(res, zero_base, 1e-2)
+
+if __name__ == '__main__':
+    test = unittest.main()

--- a/tests/cpu/test_bf16_lazy_reorder.py
+++ b/tests/cpu/test_bf16_lazy_reorder.py
@@ -248,31 +248,31 @@ class TestBinOPs(TestCase):
                 self.assertTrue(ipex.core.is_bf16_dil_tensor(x_auto_mix_a))
                 self.assertEqual(x_auto_mix_a, x_man_bf16_a.float())
 
-# class TestLinear(TestCase):
-#     def test_linear(self):
-#         rand_seed = int(get_rand_seed())
-#         print("{} rand sed: {}".format(sys._getframe().f_code.co_name, rand_seed))
-#         torch.manual_seed(rand_seed)
-#         in_features = torch.randint(3, 10, (1,)).item()
-#         out_features = torch.randint(3, 100, (1,)).item()
-#         x_auto_mix = torch.randn(3, in_features, dtype=torch.float32, device=device) * 10
-#         x_man_bf16 = x_auto_mix.to(torch.bfloat16)
+class TestLinear(TestCase):
+    def test_linear(self):
+        rand_seed = int(get_rand_seed())
+        print("{} rand sed: {}".format(sys._getframe().f_code.co_name, rand_seed))
+        torch.manual_seed(rand_seed)
+        in_features = torch.randint(3, 10, (1,)).item()
+        out_features = torch.randint(3, 100, (1,)).item()
+        x_auto_mix = torch.randn(3, in_features, dtype=torch.float32, device=device) * 10
+        x_man_bf16 = x_auto_mix.to(torch.bfloat16)
 
-#         for bias in [True, False]:
-#             linear = torch.nn.Linear(in_features, out_features, bias=bias)
+        for bias in [True, False]:
+            linear = torch.nn.Linear(in_features, out_features, bias=bias)
 
-#             linear_auto_mix = copy.deepcopy(linear).to(device=device)
-#             linear_man_bf16 = copy.deepcopy(linear).to(device=device).to(torch.bfloat16)
+            linear_auto_mix = copy.deepcopy(linear).to(device=device)
+            linear_man_bf16 = copy.deepcopy(linear).to(device=device).to(torch.bfloat16)
 
-#             with AutoDNNL(True), AutoMixPrecision(False):
-#                 res_man_bf16 = linear_man_bf16(x_man_bf16)
-#                 self.assertEqual(res_man_bf16.dtype, torch.bfloat16)
+            with AutoDNNL(True), AutoMixPrecision(False):
+                res_man_bf16 = linear_man_bf16(x_man_bf16)
+                self.assertEqual(res_man_bf16.dtype, torch.bfloat16)
 
-#                 with AutoMixPrecision(True):
-#                     res_auto_mix = linear_auto_mix(x_auto_mix)
-#                     self.assertEqual(res_auto_mix.dtype, torch.float)
-#                     self.assertTrue(ipex.core.is_bf16_dil_tensor(res_auto_mix))
-#                     self.assertEqual(res_auto_mix, res_man_bf16.float())
+                with AutoMixPrecision(True):
+                    res_auto_mix = linear_auto_mix(x_auto_mix)
+                    self.assertEqual(res_auto_mix.dtype, torch.float)
+                    self.assertTrue(ipex.core.is_bf16_dil_tensor(res_auto_mix))
+                    self.assertEqual(res_auto_mix, res_man_bf16.float())
 
 class TestPool(TestCase):
     def test_avg_pool2d(self):
@@ -395,7 +395,6 @@ class TestLinearAlgebraOps(TestCase):
     def _gen_mm_tensor(self, seed, batches = None):
         torch.manual_seed(seed)
         M, N, O = 23, 8, 12
-        M, N, O = 3, 2, 3
         if batches != None:
             x_auto_mix_a = torch.randn(batches, M, N, dtype=torch.float32, device=device)
             x_auto_mix_b = torch.randn(batches, N, O, dtype=torch.float32, device=device)

--- a/torch_ipex/csrc/aten_ipex_bridge.cpp
+++ b/torch_ipex/csrc/aten_ipex_bridge.cpp
@@ -457,7 +457,7 @@ std::vector<at::Tensor> shallowFallbackToCPUTensorList(const at::TensorList& ten
 void reorderTensorToScalarTypeForDNNL(const at::Tensor& ipexTensor, at::ScalarType dstScalarType) {
   TORCH_INTERNAL_ASSERT_DEBUG_ONLY(dstScalarType == at::kBFloat16);
   auto tensor_dtype = ipexTensor.scalar_type();
-  TORCH_CHECK(!(tensor_dtype == at::kBFloat16), "Please disalbe auto mix-precision if you want to enable BFloat16 manually");
+  TORCH_CHECK(!(tensor_dtype == at::kBFloat16), "Please disable auto mix-precision if you want to enable BFloat16 manually");
   if (tensor_dtype != at::kFloat)
     return;
 

--- a/torch_ipex/csrc/aten_ipex_bridge.cpp
+++ b/torch_ipex/csrc/aten_ipex_bridge.cpp
@@ -461,12 +461,10 @@ void reorderTensorToScalarTypeForDNNL(const at::Tensor& ipexTensor, at::ScalarTy
   if (tensor_dtype != at::kFloat)
     return;
 
-  TORCH_INTERNAL_ASSERT_DEBUG_ONLY((check_tensor_own_shade_context(ipexTensor)));
   dil::tensor new_type_dil_tensor;
-
-  cpu::ShadeDataContext *shade_context = (cpu::ShadeDataContext*)(ipexTensor.storage().data_ptr().get_context());
-  if (cpu::ShadeDataContext::isDilOwnTheTensor(ipexTensor)) {
+  if (check_tensor_own_shade_context(ipexTensor) && cpu::ShadeDataContext::isDilOwnTheTensor(ipexTensor)) {
     // The buffer ownership is DIL
+    cpu::ShadeDataContext *shade_context = (cpu::ShadeDataContext*)(ipexTensor.storage().data_ptr().get_context());
     TORCH_INTERNAL_ASSERT_DEBUG_ONLY(shade_context->dil_tensor.has_value());
     dil::tensor&& dil_tensor = std::move(shade_context->dil_tensor.value());
     if (get_at_data_type(dil_tensor.get_data_type()) == dstScalarType) {

--- a/torch_ipex/csrc/aten_ipex_bridge.cpp
+++ b/torch_ipex/csrc/aten_ipex_bridge.cpp
@@ -91,7 +91,7 @@ void reorderDilTensorToPublic(const at::Tensor& ipexTensor) {
     TORCH_INTERNAL_ASSERT_DEBUG_ONLY(shade_data_context->cpu_del_fun == nullptr);
 
     auto aten_tensor_scalar_type = ipexTensor.scalar_type();
-    TORCH_INTERNAL_ASSERT_DEBUG_ONLY(aten_tensor_scalar_type == at::kFloat);
+    TORCH_INTERNAL_ASSERT_DEBUG_ONLY(aten_tensor_scalar_type == at::kFloat || aten_tensor_scalar_type == at::kBFloat16);
     pub_tensor = dil_tensor.to_public(nullptr, get_dil_data_type(aten_tensor_scalar_type));
   }
 

--- a/torch_ipex/csrc/aten_ipex_bridge.cpp
+++ b/torch_ipex/csrc/aten_ipex_bridge.cpp
@@ -64,25 +64,39 @@ at::Tensor shallowFallbackToCPUTensorImpl(const at::Tensor& ipexTensor);
 void reorderDilTensorToPublic(const at::Tensor& ipexTensor) {
   void *data_ctx = ipexTensor.unsafeGetTensorImpl()->storage().data_ptr().get_context();
   cpu::ShadeDataContext *shade_data_context = (cpu::ShadeDataContext*)data_ctx;
-#if defined(_DEBUG)
   TORCH_INTERNAL_ASSERT_DEBUG_ONLY(! (shade_data_context->dil_tensor->is_empty()));
-#endif
   dil::tensor &dil_tensor = *shade_data_context->dil_tensor;
+  dil::tensor pub_tensor;
 
   if (dil_tensor.is_public_format()) {
-#if defined(_DEBUG)
-    TORCH_INTERNAL_ASSERT_DEBUG_ONLY(shade_data_context->cpu_raw_data == shade_data_context->dil_tensor->get_data_handle());
-    TORCH_INTERNAL_ASSERT_DEBUG_ONLY(shade_data_context->cpu_raw_data != nullptr);
-    TORCH_INTERNAL_ASSERT_DEBUG_ONLY(shade_data_context->cpu_del_fun != nullptr);
-#endif
+    if (cpu::ShadeDataContext::isTensorMixPrecision(ipexTensor)) {
+      auto& data_ptr = ipexTensor.storage().unsafeGetStorageImpl()->data_ptr();
+      TORCH_INTERNAL_ASSERT_DEBUG_ONLY(data_ptr.get() == nullptr);
+      TORCH_INTERNAL_ASSERT_DEBUG_ONLY(shade_data_context->cpu_raw_data == nullptr);
+      TORCH_INTERNAL_ASSERT_DEBUG_ONLY(shade_data_context->cpu_del_fun == nullptr);
+
+      auto aten_tensor_scalar_type = ipexTensor.scalar_type();
+      TORCH_INTERNAL_ASSERT_DEBUG_ONLY(aten_tensor_scalar_type == at::kFloat);
+      auto new_type_desc = dil_tensor.get_desc().to_type(get_dil_data_type(aten_tensor_scalar_type));
+      pub_tensor.init(new_type_desc);
+      pub_tensor.feed_from(dil_tensor);
+    } else {
+      TORCH_INTERNAL_ASSERT_DEBUG_ONLY(shade_data_context->cpu_raw_data == shade_data_context->dil_tensor->get_data_handle());
+      TORCH_INTERNAL_ASSERT_DEBUG_ONLY(shade_data_context->cpu_raw_data != nullptr);
+      TORCH_INTERNAL_ASSERT_DEBUG_ONLY(shade_data_context->cpu_del_fun != nullptr);
+    }
   } else {
-#if defined(_DEBUG)
     auto& data_ptr = ipexTensor.storage().unsafeGetStorageImpl()->data_ptr();
     TORCH_INTERNAL_ASSERT_DEBUG_ONLY(data_ptr.get_deleter() == &(cpu::ShadeDataContext::freeShadeDataContext));
     TORCH_INTERNAL_ASSERT_DEBUG_ONLY(shade_data_context->cpu_del_fun == nullptr);
-#endif
-    auto pub_tensor = dil_tensor.to_public(nullptr, dil_tensor.get_data_type());
 
+    auto aten_tensor_scalar_type = ipexTensor.scalar_type();
+    TORCH_INTERNAL_ASSERT_DEBUG_ONLY(aten_tensor_scalar_type == at::kFloat);
+    pub_tensor = dil_tensor.to_public(nullptr, get_dil_data_type(aten_tensor_scalar_type));
+  }
+
+  if (!pub_tensor.is_empty()) {
+    TORCH_INTERNAL_ASSERT_DEBUG_ONLY(pub_tensor.is_public_format());
     cpu::ShadeDataContext *new_shade_data_context = cpu::ShadeDataContext::allocShadeDataContext();
     new_shade_data_context->data_type = cpu::SHADE_DATA_TYPE::DIL;
     new_shade_data_context->dil_tensor = pub_tensor;
@@ -189,7 +203,7 @@ at::Tensor shallowFallbackToCPUTensor(const at::Tensor& ipexTensor) {
   }
 
   // Branch 2: Dense Tensor
-  
+
   // Branch 2.0: Dense + CPU Tensor + w/o context.
   // Supposing only Aten inplace op w/ Resize internally will run into this branch,
   // since new DataPtr has replaced orignal one, then DPCPP tensor loses context info.
@@ -304,7 +318,7 @@ at::Tensor shallowUpgradeToDPCPPTensor(const at::Tensor& cpuTensor) {
     ipex_impl->copy_meta_info(cpu_tensor_impl);
     TORCH_INTERNAL_ASSERT_DEBUG_ONLY(! cpuTensor.requires_grad());
     CHECK_TENSOR_CRITICAL(_tensor, cpuTensor, true);
-    //TODO: Cannot set reserved_ 
+    //TODO: Cannot set reserved_
     //      dest_impl->reserved_ = src_impl->reserved_;
     attachShadeDataContext(_tensor);
     return _tensor;
@@ -441,25 +455,58 @@ std::vector<at::Tensor> shallowFallbackToCPUTensorList(const at::TensorList& ten
 
 
 void reorderTensorToScalarTypeForDNNL(const at::Tensor& ipexTensor, at::ScalarType dstScalarType) {
-  TORCH_CHECK(dstScalarType == at::kBFloat16 || dstScalarType == at::kFloat);
+  TORCH_CHECK(dstScalarType == at::kBFloat16);
   auto tensor_dtype = ipexTensor.scalar_type();
-  TORCH_CHECK(tensor_dtype == at::kBFloat16 || tensor_dtype == at::kFloat);
-  if (tensor_dtype == dstScalarType)
+  TORCH_INTERNAL_ASSERT_DEBUG_ONLY(tensor_dtype == at::kFloat);
+  if (tensor_dtype != at::kFloat)
     return;
 
-  if (check_tensor_own_shade_context(ipexTensor)) {
-    // Shade data context has been attached
-    if (cpu::ShadeDataContext::isDilTensor(ipexTensor)) {
-      cpu::ShadeDataContext *shade_context = (cpu::ShadeDataContext*)(ipexTensor.storage().data_ptr().get_context());
-      shade_context->dil_tensor->to_type(get_dil_data_type(dstScalarType));
-      IPEXTensorImpl* ipex_tensor_impl = (IPEXTensorImpl *)ipexTensor.unsafeGetTensorImpl();
-      ipex_tensor_impl->reset_data_type(dstScalarType);
-      ipex_tensor_impl->storage().unsafeGetStorageImpl()->set_dtype(at::scalarTypeToTypeMeta(dstScalarType));
-      return;
+  TORCH_INTERNAL_ASSERT_DEBUG_ONLY((check_tensor_own_shade_context(ipexTensor)));
+  cpu::ShadeDataContext *shade_context = (cpu::ShadeDataContext*)(ipexTensor.storage().data_ptr().get_context());
+  if (cpu::ShadeDataContext::isDilOwnTheTensor(ipexTensor)) {
+    TORCH_INTERNAL_ASSERT_DEBUG_ONLY(shade_context->dil_tensor.has_value());
+    dil::tensor&& dil_tensor = std::move(shade_context->dil_tensor.value());
+    if (get_at_data_type(dil_tensor.get_data_type()) == dstScalarType) {
+      // The data type of DIL tensor is same as the destination data type
+      // DO NOTHING
+    } else {
+      TORCH_CHECK(check_tensor_own_whole_storage(ipexTensor),
+        "Intel Extension for PyTorch does not support the data is just a part of its storage for auto mix-precision.");
+
+      auto new_type_desc = dil_tensor.get_desc().to_type(get_dil_data_type(dstScalarType));
+      dil::tensor new_type_dil_tensor{new_type_desc};
+      new_type_dil_tensor.feed_from(shade_context->dil_tensor.value());
+      shade_context->dil_tensor = new_type_dil_tensor;
+      shade_context->mix_prec_type = cpu::MIX_PREC_TYPE::MIX_BF_FP32;
     }
+    return;
   }
 
-  return reorderTensorToScalaraType(ipexTensor, dstScalarType);
+  // The buffer ownership is CPU
+  TORCH_CHECK(check_tensor_own_whole_storage(ipexTensor),
+    "Intel Extension for PyTorch does not support the data is just a part of its storage for auto mix-precision.");
+  TORCH_INTERNAL_ASSERT_DEBUG_ONLY(tensor_dtype == at::kFloat);
+
+  dil::tensor&& temp_dil_tensor = cpu::dbl::comm::dil_tensor_from_dense(ipexTensor);
+  dil::tensor new_type_dil_tensor = temp_dil_tensor.get_desc().to_type(get_dil_data_type(dstScalarType));;
+  new_type_dil_tensor.feed_from(temp_dil_tensor);
+
+  // Build new shade data context
+  cpu::ShadeDataContext *new_shade_data_context = cpu::ShadeDataContext::allocShadeDataContext();
+  new_shade_data_context->data_type = cpu::SHADE_DATA_TYPE::DIL;
+  new_shade_data_context->dil_tensor = new_type_dil_tensor;
+  new_shade_data_context->mix_prec_type = cpu::MIX_PREC_TYPE::MIX_BF_FP32;
+
+  // Create a new DataPtr instances because the DataPtr class does not support set
+  // its data or context directly
+  c10::DataPtr shade_data_ptr(
+    nullptr,
+    new_shade_data_context,
+    &(cpu::ShadeDataContext::freeShadeDataContext),
+    ipexTensor.device().type());
+
+  IPEXTensorImpl* ipex_tensor_impl = (IPEXTensorImpl *)ipexTensor.unsafeGetTensorImpl();
+  ipex_tensor_impl->storage().set_data_ptr(std::move(shade_data_ptr));
 }
 
 

--- a/torch_ipex/csrc/aten_ipex_bridge.cpp
+++ b/torch_ipex/csrc/aten_ipex_bridge.cpp
@@ -455,9 +455,9 @@ std::vector<at::Tensor> shallowFallbackToCPUTensorList(const at::TensorList& ten
 
 
 void reorderTensorToScalarTypeForDNNL(const at::Tensor& ipexTensor, at::ScalarType dstScalarType) {
-  TORCH_CHECK(dstScalarType == at::kBFloat16);
+  TORCH_INTERNAL_ASSERT_DEBUG_ONLY(dstScalarType == at::kBFloat16);
   auto tensor_dtype = ipexTensor.scalar_type();
-  TORCH_INTERNAL_ASSERT_DEBUG_ONLY(tensor_dtype == at::kFloat);
+  TORCH_CHECK(!(tensor_dtype == at::kBFloat16), "Please disalbe auto mix-precision if you want to enable BFloat16 manually");
   if (tensor_dtype != at::kFloat)
     return;
 

--- a/torch_ipex/csrc/cpu/DevOPs.cpp
+++ b/torch_ipex/csrc/cpu/DevOPs.cpp
@@ -48,10 +48,15 @@ at::Tensor AtenIpexCPUDev::dil_convolution(
 
   CHECK_DNNL_OP_PRE_COND(input);
   CHECK_DNNL_OP_PRE_COND(weight);
+
+  dbl::comm::reorder_to_bf16_for_mix_prec(input);
+  dbl::comm::reorder_to_bf16_for_mix_prec(weight);
+
   dil_input = dbl::comm::try_gen_dil_tensor(input);
   dil_weight = dbl::comm::try_gen_dil_tensor(weight);
   if (bias.defined()) {
     CHECK_DNNL_OP_PRE_COND(bias);
+    dbl::comm::reorder_to_bf16_for_mix_prec(bias);
     dil_bias = dbl::comm::try_gen_dil_tensor(bias);
   }
 
@@ -134,7 +139,7 @@ std::tuple<at::Tensor, at::Tensor> dil_convolution_backward_weights(
     return std::make_tuple(
         dbl::comm::gen_aten_tensor_by(std::move(dil_grad_weight)),
         at::Tensor());
-  } 
+  }
 }
 
 std::tuple<at::Tensor,at::Tensor,at::Tensor> AtenIpexCPUDev::dil_convolution_backward(
@@ -143,6 +148,11 @@ std::tuple<at::Tensor,at::Tensor,at::Tensor> AtenIpexCPUDev::dil_convolution_bac
 {
   DEBUG("AtenIpexCPUDev::dil_convolution_backward\n");
   at::Tensor grad_output = grad_output_t.is_contiguous() ? grad_output_t : grad_output_t.contiguous();
+
+  dbl::comm::reorder_to_bf16_for_mix_prec(input);
+  dbl::comm::reorder_to_bf16_for_mix_prec(grad_output);
+  dbl::comm::reorder_to_bf16_for_mix_prec(weight);
+
   at::Tensor grad_input, grad_weight, grad_bias;
   if (output_mask[0]) {
     grad_input = dil_convolution_backward_input(
@@ -232,6 +242,11 @@ at::Tensor& AtenIpexCPUDev::dil_add_out(
   DEBUG("AtenIpexCPUDev::dil_add_out\n");
   CHECK_DNNL_OP_PRE_COND(self);
   CHECK_DNNL_OP_PRE_COND(other);
+
+  dbl::comm::reorder_to_bf16_for_mix_prec(self);
+  dbl::comm::reorder_to_bf16_for_mix_prec(other);
+  dbl::comm::reorder_to_bf16_for_mix_prec(result);
+
   dil::tensor x = dbl::comm::try_gen_dil_tensor(self);
   dil::tensor y = dbl::comm::try_gen_dil_tensor(other);
 
@@ -248,6 +263,10 @@ at::Tensor AtenIpexCPUDev::dil_add(const at::Tensor& self, const at::Tensor& oth
   DEBUG("AtenIpexCPUDev::dil_add\n");
   CHECK_DNNL_OP_PRE_COND(self);
   CHECK_DNNL_OP_PRE_COND(other);
+
+  dbl::comm::reorder_to_bf16_for_mix_prec(self);
+  dbl::comm::reorder_to_bf16_for_mix_prec(other);
+
   dil::tensor x = dbl::comm::try_gen_dil_tensor(self);
   dil::tensor y = dbl::comm::try_gen_dil_tensor(other);
 
@@ -262,6 +281,10 @@ at::Tensor & AtenIpexCPUDev::dil_add_(at::Tensor& self, const at::Tensor& other,
   DEBUG("AtenIpexCPUDev::dil_add_\n");
   CHECK_DNNL_OP_PRE_COND(self);
   CHECK_DNNL_OP_PRE_COND(other);
+
+  dbl::comm::reorder_to_bf16_for_mix_prec(self);
+  dbl::comm::reorder_to_bf16_for_mix_prec(other);
+
   auto dil_self = dbl::comm::try_gen_dil_tensor(self);
   auto dil_other = dbl::comm::try_gen_dil_tensor(other);
 
@@ -279,6 +302,10 @@ at::Tensor& AtenIpexCPUDev::dil_mul_out(at::Tensor& result, const at::Tensor& se
   CHECK_DNNL_OP_PRE_COND(self);
   CHECK_DNNL_OP_PRE_COND(other);
 
+  dbl::comm::reorder_to_bf16_for_mix_prec(self);
+  dbl::comm::reorder_to_bf16_for_mix_prec(other);
+  dbl::comm::reorder_to_bf16_for_mix_prec(result);
+
   auto dil_result = dbl::comm::try_gen_dil_tensor(result);
   auto dil_self = dbl::comm::try_gen_dil_tensor(self);
   auto dil_other = dbl::comm::try_gen_dil_tensor(other);
@@ -292,29 +319,38 @@ at::Tensor& AtenIpexCPUDev::dil_mul_out(at::Tensor& result, const at::Tensor& se
 
 at::Tensor AtenIpexCPUDev::dil_mul(const at::Tensor& self, const at::Tensor& other) {
   DEBUG("AtenIpexCPUDev::dil_mul\n");
+
+  dbl::comm::reorder_to_bf16_for_mix_prec(self);
+  dbl::comm::reorder_to_bf16_for_mix_prec(other);
+
   at::Tensor result = dbl::comm::empty_dil_tensor(self.sizes(), self.options());
+
   return dil_mul_out(result, self, other);
 }
 
 at::Tensor& AtenIpexCPUDev::dil_mul_(at::Tensor& self, const at::Tensor& other) {
   DEBUG("AtenIpexCPUDev::dil_mul_\n");
+
+  dbl::comm::reorder_to_bf16_for_mix_prec(self);
+  dbl::comm::reorder_to_bf16_for_mix_prec(other);
+
   return dil_mul_out(self, self, other);
 }
 
 void matmul_common(
     const dil::tensor &x,
     const dil::tensor &w,
-    const dil::tensor &bias, 
+    const dil::tensor &bias,
     dil::tensor &y,
     at::Scalar beta=1,
-    at::Scalar alpha=1, 
+    at::Scalar alpha=1,
     const dil::attr_t& attr = dil::attr_t()) {
   DEBUG("AtenIpexCPUDev::matmul_common\n");
   float dst_coeff = alpha.to<float>();
   float sum_coeff = beta.to<float>();
-  if (!bias.is_empty()) { 
+  if (!bias.is_empty()) {
     // DNNL only supports bias in 1xN dims
-    // use bias for sum can save tensor memory copy 
+    // use bias for sum can save tensor memory copy
     if (dst_coeff == 1.0f  && sum_coeff == 1.0f && bias.get_dim(0) == 1) {
       dil::matmul_forward::compute(x, w, bias, y);
       return;
@@ -327,9 +363,13 @@ void matmul_common(
 }
 
 at::Tensor AtenIpexCPUDev::dil_bmm(
-    const at::Tensor& self, 
+    const at::Tensor& self,
     const at::Tensor& mat2) {
   DEBUG("AtenIpexCPUDev::dil_bmm\n");
+
+  dbl::comm::reorder_to_bf16_for_mix_prec(self);
+  dbl::comm::reorder_to_bf16_for_mix_prec(mat2);
+
   auto self_size = self.sizes();
   std::vector<int64_t> result_size(self_size.begin(), self_size.end()-1);
   result_size.push_back(mat2.size(-1));
@@ -338,12 +378,17 @@ at::Tensor AtenIpexCPUDev::dil_bmm(
 }
 
 at::Tensor& AtenIpexCPUDev::dil_bmm_out(
-    at::Tensor &result, 
-    const at::Tensor& batch1, 
+    at::Tensor &result,
+    const at::Tensor& batch1,
     const at::Tensor& batch2) {
   DEBUG("AtenIpexCPUDev::dil_bmm_out\n");
   CHECK_DNNL_OP_PRE_COND(batch1);
   CHECK_DNNL_OP_PRE_COND(batch2);
+
+  dbl::comm::reorder_to_bf16_for_mix_prec(result);
+  dbl::comm::reorder_to_bf16_for_mix_prec(batch1);
+  dbl::comm::reorder_to_bf16_for_mix_prec(batch2);
+
   const dil::tensor x = dbl::comm::try_gen_dil_tensor(batch1);
   const dil::tensor w = dbl::comm::try_gen_dil_tensor(batch2);
   dil::tensor y = dbl::comm::try_gen_dil_tensor(result);
@@ -358,6 +403,10 @@ at::Tensor AtenIpexCPUDev::dil_mm(
     const at::Tensor& self,
     const at::Tensor& mat2) {
   DEBUG("AtenIpexCPUDev::dil_mm\n");
+
+  dbl::comm::reorder_to_bf16_for_mix_prec(self);
+  dbl::comm::reorder_to_bf16_for_mix_prec(mat2);
+
   return dil_bmm(self, mat2);
 }
 
@@ -366,20 +415,31 @@ at::Tensor& AtenIpexCPUDev::dil_mm_out(
     const at::Tensor& self,
     const at::Tensor& mat2) {
   DEBUG("AtenIpexCPUDev::dil_mm_out\n");
+
+  dbl::comm::reorder_to_bf16_for_mix_prec(result);
+  dbl::comm::reorder_to_bf16_for_mix_prec(self);
+  dbl::comm::reorder_to_bf16_for_mix_prec(mat2);
+
   return dil_bmm_out(result, self, mat2);
 }
 
 at::Tensor& AtenIpexCPUDev::dil_baddbmm_out(
-    at::Tensor &result, 
-    const at::Tensor& self, 
-    const at::Tensor& batch1, 
-    const at::Tensor& batch2, 
-    at::Scalar beta, 
+    at::Tensor &result,
+    const at::Tensor& self,
+    const at::Tensor& batch1,
+    const at::Tensor& batch2,
+    at::Scalar beta,
     at::Scalar alpha) {
   DEBUG("AtenIpexCPUDev::dil_baddbmm_out\n");
   CHECK_DNNL_OP_PRE_COND(self);
   CHECK_DNNL_OP_PRE_COND(batch1);
   CHECK_DNNL_OP_PRE_COND(batch2);
+
+  dbl::comm::reorder_to_bf16_for_mix_prec(result);
+  dbl::comm::reorder_to_bf16_for_mix_prec(self);
+  dbl::comm::reorder_to_bf16_for_mix_prec(batch1);
+  dbl::comm::reorder_to_bf16_for_mix_prec(batch2);
+
   const dil::tensor x = dbl::comm::try_gen_dil_tensor(batch1);
   const dil::tensor w = dbl::comm::try_gen_dil_tensor(batch2);
   dil::tensor bias;
@@ -407,6 +467,11 @@ at::Tensor AtenIpexCPUDev::dil_baddbmm(
     at::Scalar beta,
     at::Scalar alpha) {
   DEBUG("AtenIpexCPUDev::dil_baddbmm\n");
+
+  dbl::comm::reorder_to_bf16_for_mix_prec(self);
+  dbl::comm::reorder_to_bf16_for_mix_prec(batch1);
+  dbl::comm::reorder_to_bf16_for_mix_prec(batch2);
+
   auto self_size = batch1.sizes();
   std::vector<int64_t> result_size(self_size.begin(), self_size.end()-1);
   result_size.push_back(batch2.size(-1));
@@ -421,6 +486,11 @@ at::Tensor& AtenIpexCPUDev::dil_baddbmm_(
     at::Scalar beta,
     at::Scalar alpha) {
   DEBUG("AtenIpexCPUDev::dil_baddbmm_\n");
+
+  dbl::comm::reorder_to_bf16_for_mix_prec(self);
+  dbl::comm::reorder_to_bf16_for_mix_prec(batch1);
+  dbl::comm::reorder_to_bf16_for_mix_prec(batch2);
+
   at::Tensor result = at::empty({0}, self.options());
   return dil_baddbmm_out(self, result, batch1, batch2, beta, alpha);
 }
@@ -432,7 +502,13 @@ at::Tensor& AtenIpexCPUDev::dil_addmm_out(
     const at::Tensor& mat2,
     at::Scalar beta,
     at::Scalar alpha) {
-  DEBUG("AtenIpexCPUDev::dil_addmm_out\n");   
+  DEBUG("AtenIpexCPUDev::dil_addmm_out\n");
+
+  dbl::comm::reorder_to_bf16_for_mix_prec(result);
+  dbl::comm::reorder_to_bf16_for_mix_prec(self);
+  dbl::comm::reorder_to_bf16_for_mix_prec(mat1);
+  dbl::comm::reorder_to_bf16_for_mix_prec(mat2);
+
   return dil_baddbmm_out(result, self, mat1, mat2, beta, alpha);
 }
 
@@ -443,6 +519,11 @@ at::Tensor AtenIpexCPUDev::dil_addmm(
     at::Scalar beta,
     at::Scalar alpha) {
   DEBUG("AtenIpexCPUDev::dil_addmm\n");
+
+  dbl::comm::reorder_to_bf16_for_mix_prec(self);
+  dbl::comm::reorder_to_bf16_for_mix_prec(batch1);
+  dbl::comm::reorder_to_bf16_for_mix_prec(batch2);
+
   return dil_baddbmm(self, batch1, batch2, beta, alpha);
 }
 
@@ -453,6 +534,11 @@ at::Tensor& AtenIpexCPUDev::dil_addmm_(
     at::Scalar beta,
     at::Scalar alpha) {
   DEBUG("AtenIpexCPUDev::dil_addmm_\n");
+
+  dbl::comm::reorder_to_bf16_for_mix_prec(self);
+  dbl::comm::reorder_to_bf16_for_mix_prec(batch1);
+  dbl::comm::reorder_to_bf16_for_mix_prec(batch2);
+
   return dil_baddbmm_(self, batch1, batch2, beta, alpha);
 }
 
@@ -467,6 +553,12 @@ at::Tensor& AtenIpexCPUDev::dil_addbmm_out(
   CHECK_DNNL_OP_PRE_COND(self);
   CHECK_DNNL_OP_PRE_COND(batch1);
   CHECK_DNNL_OP_PRE_COND(batch2);
+
+  dbl::comm::reorder_to_bf16_for_mix_prec(result);
+  dbl::comm::reorder_to_bf16_for_mix_prec(self);
+  dbl::comm::reorder_to_bf16_for_mix_prec(batch1);
+  dbl::comm::reorder_to_bf16_for_mix_prec(batch2);
+
   // addbmm(batch1*batch2) [b,n,m] * [b,m,p] = [n,p] can be treated as:
   // [n, b*m] * [b*m, p] = [n, p]
   // For batch1: reorder from [b, n, m] to [n, b, m], reshape to [n, b*m]
@@ -484,8 +576,8 @@ at::Tensor& AtenIpexCPUDev::dil_addbmm_out(
   auto w_ = w.reshape(w_dims);
   dil::tensor y = dbl::comm::try_gen_dil_tensor(result);
   auto attr_ = dil::attr_t::fuse_sum();
- 
-  dil::tensor bias; 
+
+  dil::tensor bias;
   if (self.numel() != 0) {
     bias = dbl::comm::try_gen_dil_tensor(self);
     if (bias.ndims() < x_.ndims()) {
@@ -508,6 +600,11 @@ at::Tensor AtenIpexCPUDev::dil_addbmm(
     at::Scalar beta,
     at::Scalar alpha) {
   DEBUG("AtenIpexCPUDev::dil_addbmm\n");
+
+  dbl::comm::reorder_to_bf16_for_mix_prec(self);
+  dbl::comm::reorder_to_bf16_for_mix_prec(batch1);
+  dbl::comm::reorder_to_bf16_for_mix_prec(batch2);
+
   at::Tensor result = dbl::comm::empty_dil_tensor(self.sizes(), self.options());
   return dil_addbmm_out(result, self, batch1, batch2, beta, alpha);
 }
@@ -519,6 +616,11 @@ at::Tensor& AtenIpexCPUDev::dil_addbmm_(
     at::Scalar beta,
     at::Scalar alpha) {
   DEBUG("AtenIpexCPUDev::dil_addbmm_\n");
+
+  dbl::comm::reorder_to_bf16_for_mix_prec(self);
+  dbl::comm::reorder_to_bf16_for_mix_prec(batch1);
+  dbl::comm::reorder_to_bf16_for_mix_prec(batch2);
+
   at::Tensor result = at::empty({0}, self.options());
   return dil_addbmm_out(self, result, batch1, batch2, beta, alpha);
 }
@@ -533,6 +635,9 @@ at::Tensor AtenIpexCPUDev::dil_linear(
   TORCH_CHECK(self.dim() >= 2,
       "dil_linear: input needs to has dim at least 2, input dim ", self.dim());
 
+  dbl::comm::reorder_to_bf16_for_mix_prec(self);
+  dbl::comm::reorder_to_bf16_for_mix_prec(weight);
+
   // reshape first if input dim is greater than 2 and the reshape will cost a memory copy.
   auto self_reshaped = self.dim() > 2 ? self.reshape({-1, self.size(self.dim() - 1)}) : self;
   const dil::tensor x = dbl::comm::try_gen_dil_tensor(self_reshaped);
@@ -540,6 +645,7 @@ at::Tensor AtenIpexCPUDev::dil_linear(
 
   dil::tensor y;
   if (bias.defined()) {
+    dbl::comm::reorder_to_bf16_for_mix_prec(bias);
     const dil::tensor b = dbl::comm::try_gen_dil_tensor(bias);
     dil::inner_product_forward::compute(x, w, b, y);
   } else {
@@ -566,6 +672,9 @@ at::Tensor AtenIpexCPUDev::dil_linear_fuse_relu(
   TORCH_CHECK(self.dim() >= 2,
       "dil_linear: input needs to has dim at least 2, input dim ", self.dim());
 
+  dbl::comm::reorder_to_bf16_for_mix_prec(self);
+  dbl::comm::reorder_to_bf16_for_mix_prec(weight);
+
   // reshape first if input dim is greater than 2 and the reshape will cost a memory copy.
   auto self_reshaped = self.dim() > 2 ? self.reshape({-1, self.size(self.dim() - 1)}) : self;
   const dil::tensor x = dbl::comm::try_gen_dil_tensor(self_reshaped);
@@ -574,6 +683,7 @@ at::Tensor AtenIpexCPUDev::dil_linear_fuse_relu(
   dil::tensor y;
   if (bias.has_value()) {
     at::Tensor bias_vec = bias.value();
+    dbl::comm::reorder_to_bf16_for_mix_prec(bias_vec);
     const dil::tensor b = dbl::comm::try_gen_dil_tensor(bias_vec);
     dil::inner_product_forward::compute(x, w, b, y,
                                         /*src_scales=*/dil::scale_t(),
@@ -601,6 +711,10 @@ at::Tensor AtenIpexCPUDev::dil_linear_fuse_relu(
 at::Tensor AtenIpexCPUDev::dil_linear_backward_input(
     at::IntArrayRef input_size, const at::Tensor& grad_output, const at::Tensor& weight){
   DEBUG("AtenIpexCPUDev::dil_linear_backward_input\n");
+
+  dbl::comm::reorder_to_bf16_for_mix_prec(grad_output);
+  dbl::comm::reorder_to_bf16_for_mix_prec(weight);
+
   auto grad_output_reshaped = grad_output.dim() > 2 ?
     grad_output.reshape({-1, grad_output.size(grad_output.dim() - 1)}) : grad_output;
   dil::tensor grady = dbl::comm::try_gen_dil_tensor(grad_output_reshaped);
@@ -623,6 +737,11 @@ at::Tensor AtenIpexCPUDev::dil_linear_backward_input(
 std::tuple<at::Tensor, at::Tensor> AtenIpexCPUDev::dil_linear_backward_weights(
     const at::Tensor& grad_output, const at::Tensor& input, const at::Tensor& weight, bool bias_defined) {
   DEBUG("AtenIpexCPUDev::dil_linear_backward_weights\n");
+
+  dbl::comm::reorder_to_bf16_for_mix_prec(grad_output);
+  dbl::comm::reorder_to_bf16_for_mix_prec(input);
+  dbl::comm::reorder_to_bf16_for_mix_prec(weight);
+
   auto grad_output_reshaped = grad_output.dim() > 2 ?
     grad_output.reshape({-1, grad_output.size(grad_output.dim() - 1)}) : grad_output;
   auto input_reshaped = input.dim() > 2 ? input.reshape({-1, input.size(input.dim() - 1)}) : input;
@@ -651,6 +770,11 @@ std::tuple<at::Tensor, at::Tensor, at::Tensor> AtenIpexCPUDev::dil_linear_backwa
   CHECK_DNNL_OP_PRE_COND(input);
   CHECK_DNNL_OP_PRE_COND(grad_output);
   CHECK_DNNL_OP_PRE_COND(weight);
+
+  dbl::comm::reorder_to_bf16_for_mix_prec(grad_output);
+  dbl::comm::reorder_to_bf16_for_mix_prec(input);
+  dbl::comm::reorder_to_bf16_for_mix_prec(weight);
+
   at::Tensor grad_input, grad_weight, grad_bias;
   if (output_mask[0]) {
     grad_input = dil_linear_backward_input(input.sizes(), grad_output, weight);
@@ -680,6 +804,9 @@ std::tuple<at::Tensor, at::Tensor> _dil_dropout(
 at::Tensor AtenIpexCPUDev::dil_dropout(const at::Tensor& self, double ratio, bool train) {
   DEBUG("AtenIpexCPUDev::dil_dropout\n");
   CHECK_DNNL_OP_PRE_COND(self);
+
+  dbl::comm::reorder_to_bf16_for_mix_prec(self);
+
   return std::get<0>(_dil_dropout(self, ratio));
 }
 
@@ -692,10 +819,12 @@ at::Tensor AtenIpexCPUDev::dil_dropout_backward(
   if (ratio == 0 || grady.numel() == 0) {
     return grady;
   }
+
+  dbl::comm::reorder_to_bf16_for_mix_prec(grady);
+  dbl::comm::reorder_to_bf16_for_mix_prec(mask);
+
   dil::tensor dY = dbl::comm::try_gen_dil_tensor(grady);
   dil::tensor mask_dil = dbl::comm::try_gen_dil_tensor(mask);
-
-
   dil::tensor dX;
   dil::dropout_backward::compute(mask_dil, dY, dX);
   return dbl::comm::gen_aten_tensor_by(std::move(dX));
@@ -717,6 +846,9 @@ std::tuple<at::Tensor, at::Tensor, at::Tensor> AtenIpexCPUDev::dil_native_batch_
              "mkldnn_batch_norm: currently mkldnn only support 2d and 3d batchnorm");
   TORCH_CHECK(weight.defined() && bias.defined(),
              "mkldnn_batch_norm: currently mkldnn only support affine model");
+
+  dbl::comm::reorder_to_bf16_for_mix_prec(input);
+
   dil::tensor x = dbl::comm::try_gen_dil_tensor(input);
   const dil::tensor w = dbl::comm::try_gen_dil_tensor(weight);
   const dil::tensor b = dbl::comm::try_gen_dil_tensor(bias);
@@ -770,8 +902,13 @@ std::tuple<at::Tensor, at::Tensor, at::Tensor> AtenIpexCPUDev::dil_native_batch_
   DEBUG("AtenIpexCPUDev::dil_native_batch_norm_backward\n");
   CHECK_DNNL_OP_PRE_COND(input);
   CHECK_DNNL_OP_PRE_COND(weight);
+
   TORCH_CHECK(train, "mkldnn_batch_norm_backward: currently mkldnn only support train model");
   auto grad_output_contiguous = grad_output.is_contiguous() ? grad_output : grad_output.contiguous();
+
+  dbl::comm::reorder_to_bf16_for_mix_prec(grad_output);
+  dbl::comm::reorder_to_bf16_for_mix_prec(input);
+
   dil::tensor grady = dbl::comm::try_gen_dil_tensor(grad_output_contiguous);
   dil::tensor x = dbl::comm::try_gen_dil_tensor(input);
   dil::tensor w = dbl::comm::try_gen_dil_tensor(weight);
@@ -797,6 +934,9 @@ at::Tensor AtenIpexCPUDev::dil_max_pooling(
     bool ceil_mode) {
   DEBUG("AtenIpexCPUDev::dil_max_pooling\n");
   CHECK_DNNL_OP_PRE_COND(input);
+
+  dbl::comm::reorder_to_bf16_for_mix_prec(input);
+
   return dbl::pool::_dil_pooling(
       input.is_contiguous() ? input : input.contiguous(),
       kernel_size,
@@ -819,6 +959,9 @@ at::Tensor AtenIpexCPUDev::dil_avg_pool2d(
   CHECK_DNNL_OP_PRE_COND(input);
   TORCH_CHECK(!divisor_override.has_value(),
            "dil_avg_pooling operator does not support divisor");
+
+  dbl::comm::reorder_to_bf16_for_mix_prec(input);
+
   return dbl::pool::_dil_pooling(
       input.is_contiguous() ? input : input.contiguous(),
       kernel_size,
@@ -842,6 +985,9 @@ at::Tensor AtenIpexCPUDev::dil_avg_pool3d(
   CHECK_DNNL_OP_PRE_COND(input);
   TORCH_CHECK(!divisor_override.has_value(),
            "dil_avg_pooling operator does not support divisor");
+
+  dbl::comm::reorder_to_bf16_for_mix_prec(input);
+
   return dbl::pool::_dil_pooling(
       input.is_contiguous() ? input : input.contiguous(),
       kernel_size,
@@ -854,10 +1000,13 @@ at::Tensor AtenIpexCPUDev::dil_avg_pool3d(
 }
 
 at::Tensor AtenIpexCPUDev::dil_adaptive_avg_pool2d(
-    at::Tensor const& input,
+    const at::Tensor& input,
     at::IntArrayRef output_size) {
   DEBUG("AtenIpexCPUDev::dil_adaptive_avg_pool2d\n");
   CHECK_DNNL_OP_PRE_COND(input);
+
+  dbl::comm::reorder_to_bf16_for_mix_prec(input);
+
   auto output_size_vec =
       dbl::comm::expand_param_if_needed(output_size, "output_size", input.dim() - 2);
   std::vector<int64_t> kernel_size(input.dim() - 2);
@@ -872,7 +1021,7 @@ at::Tensor AtenIpexCPUDev::dil_adaptive_avg_pool2d(
   }
   std::vector<int64_t> padding{0, 0};
   std::vector<int64_t> dilation{1, 1};
-  
+
   if (input.dim() == 5) {
     padding.push_back(0);
     dilation.push_back(1);
@@ -901,6 +1050,11 @@ at::Tensor AtenIpexCPUDev::dil_max_pooling_backward(
   CHECK_DNNL_OP_PRE_COND(grad_output);
   CHECK_DNNL_OP_PRE_COND(output);
   CHECK_DNNL_OP_PRE_COND(input);
+
+  dbl::comm::reorder_to_bf16_for_mix_prec(grad_output);
+  dbl::comm::reorder_to_bf16_for_mix_prec(output);
+  dbl::comm::reorder_to_bf16_for_mix_prec(input);
+
   return dbl::pool::_dil_pooling_backward(
       grad_output.is_contiguous() ? grad_output : grad_output.contiguous(),
       output.is_contiguous() ? output : output.contiguous(),
@@ -925,7 +1079,10 @@ at::Tensor AtenIpexCPUDev::dil_avg_pool2d_backward(
   DEBUG("AtenIpexCPUDev::dil_avg_pool2d_backward\n");
   CHECK_DNNL_OP_PRE_COND(grad_output);
   CHECK_DNNL_OP_PRE_COND(input);
-  
+
+  dbl::comm::reorder_to_bf16_for_mix_prec(grad_output);
+  dbl::comm::reorder_to_bf16_for_mix_prec(input);
+
   return dbl::pool::_dil_pooling_backward(
       grad_output.is_contiguous() ? grad_output : grad_output.contiguous(),
       grad_output.is_contiguous() ? grad_output : grad_output.contiguous(),
@@ -951,6 +1108,10 @@ at::Tensor AtenIpexCPUDev::dil_avg_pool3d_backward(
   DEBUG("AtenIpexCPUDev::dil_avg_pool3d_backward\n");
   CHECK_DNNL_OP_PRE_COND(grad_output);
   CHECK_DNNL_OP_PRE_COND(input);
+
+  dbl::comm::reorder_to_bf16_for_mix_prec(grad_output);
+  dbl::comm::reorder_to_bf16_for_mix_prec(input);
+
   std::vector<int64_t> dilation{1, 1};
   return dbl::pool::_dil_pooling_backward(
       grad_output.is_contiguous() ? grad_output : grad_output.contiguous(),
@@ -971,6 +1132,10 @@ at::Tensor AtenIpexCPUDev::dil_adaptive_avg_pool2d_backward(
   DEBUG("AtenIpexCPUDev::dil_adaptive_avg_pool2d_backward\n");
   CHECK_DNNL_OP_PRE_COND(grad_output);
   CHECK_DNNL_OP_PRE_COND(input);
+
+  dbl::comm::reorder_to_bf16_for_mix_prec(grad_output);
+  dbl::comm::reorder_to_bf16_for_mix_prec(input);
+
   auto output_size_vec = grad_output.sizes();
   std::vector<int64_t> kernel_size(input.dim() - 2);
   for (size_t i = 2; i < input.dim(); ++i) {
@@ -984,13 +1149,12 @@ at::Tensor AtenIpexCPUDev::dil_adaptive_avg_pool2d_backward(
   }
   std::vector<int64_t> padding{0, 0};
   std::vector<int64_t> dilation{1, 1};
-  
+
   if (input.dim() == 5) {
     padding.push_back(0);
     dilation.push_back(1);
   }
 
- 
   return dbl::pool::_dil_pooling_backward(
       grad_output,
       grad_output,
@@ -1006,6 +1170,9 @@ at::Tensor AtenIpexCPUDev::dil_adaptive_avg_pool2d_backward(
 at::Tensor AtenIpexCPUDev::dil_relu(const at::Tensor& input) {
   DEBUG("AtenIpexCPUDev::dil_relu\n");
   CHECK_DNNL_OP_PRE_COND(input);
+
+  dbl::comm::reorder_to_bf16_for_mix_prec(input);
+
   const dil::tensor& x = dbl::comm::try_gen_dil_tensor(input);
   dil::tensor y;
   dil::eltwise_forward::compute(
@@ -1030,6 +1197,13 @@ at::Tensor& AtenIpexCPUDev::dil_relu_(at::Tensor& input) {
 }
 
 at::Tensor AtenIpexCPUDev::dil_relu_use_dst_for_bwd(const at::Tensor& grad_output, const at::Tensor& output) {
+  DEBUG("AtenIpexCPUDev::dil_relu_use_dst_for_bwd\n");
+  CHECK_DNNL_OP_PRE_COND(grad_output);
+  CHECK_DNNL_OP_PRE_COND(output);
+
+  dbl::comm::reorder_to_bf16_for_mix_prec(grad_output);
+  dbl::comm::reorder_to_bf16_for_mix_prec(output);
+
   const dil::tensor& y = dbl::comm::try_gen_dil_tensor(output);
   dil::tensor grady = dbl::comm::try_gen_dil_tensor(grad_output);
   dil::tensor gradx;
@@ -1042,6 +1216,10 @@ at::Tensor AtenIpexCPUDev::dil_threshold_backward(const at::Tensor& grad_output,
   DEBUG("AtenIpexCPUDev::dil_threshold_backward\n");
   CHECK_DNNL_OP_PRE_COND(grad_output);
   CHECK_DNNL_OP_PRE_COND(input);
+
+  dbl::comm::reorder_to_bf16_for_mix_prec(grad_output);
+  dbl::comm::reorder_to_bf16_for_mix_prec(input);
+
   // TODO: support bounded relu. `threshold` is ignored for now
   dil::tensor x = dbl::comm::try_gen_dil_tensor(input);
   dil::tensor grady = dbl::comm::try_gen_dil_tensor(grad_output);
@@ -1060,6 +1238,9 @@ at::Tensor AtenIpexCPUDev::dil__softmax(
   AT_ASSERTM(
       !half_to_float,
       "softmax with half to float conversion is not supported on Mkldnn");
+
+  dbl::comm::reorder_to_bf16_for_mix_prec(self);
+
   const int64_t wrapped_dim = at::maybe_wrap_dim(dim, self.dim());
   dil::tensor x = dbl::comm::try_gen_dil_tensor(self);
   dil::tensor y;
@@ -1076,6 +1257,11 @@ at::Tensor AtenIpexCPUDev::dil__softmax_backward_data(
   CHECK_DNNL_OP_PRE_COND(grad_output);
   CHECK_DNNL_OP_PRE_COND(output);
   CHECK_DNNL_OP_PRE_COND(self);
+
+  dbl::comm::reorder_to_bf16_for_mix_prec(grad_output);
+  dbl::comm::reorder_to_bf16_for_mix_prec(output);
+  dbl::comm::reorder_to_bf16_for_mix_prec(self);
+
   const int64_t wrapped_dim = at::maybe_wrap_dim(dim, self.dim());
   dil::tensor y = dbl::comm::try_gen_dil_tensor(output);
   auto grad_output_contiguous = grad_output.is_contiguous() ? grad_output : grad_output.contiguous();
@@ -1087,6 +1273,9 @@ at::Tensor AtenIpexCPUDev::dil__softmax_backward_data(
 
 at::Tensor AtenIpexCPUDev::dil_sigmoid(const at::Tensor& self) {
   DEBUG("AtenIpexCPUDev::dil_sigmoid\n");
+
+  dbl::comm::reorder_to_bf16_for_mix_prec(self);
+
   CHECK_DNNL_OP_PRE_COND(self);
   dil::tensor x = dbl::comm::try_gen_dil_tensor(self);
   dil::tensor y;
@@ -1098,6 +1287,9 @@ at::Tensor AtenIpexCPUDev::dil_sigmoid(const at::Tensor& self) {
 at::Tensor& AtenIpexCPUDev::dil_sigmoid_(at::Tensor& self) {
   DEBUG("AtenIpexCPUDev::dil_sigmoid_\n");
   CHECK_DNNL_OP_PRE_COND(self);
+
+  dbl::comm::reorder_to_bf16_for_mix_prec(self);
+
   dil::tensor x = dbl::comm::try_gen_dil_tensor(self);
   dil::eltwise_forward::compute(
       x, x, dil::algorithm::eltwise_logistic_use_dst_for_bwd, dil::prop_kind::forward);
@@ -1113,6 +1305,10 @@ at::Tensor AtenIpexCPUDev::dil_sigmoid_backward(
   DEBUG("AtenIpexCPUDev::dil_sigmoid_backward\n");
   CHECK_DNNL_OP_PRE_COND(grad_output);
   CHECK_DNNL_OP_PRE_COND(output);
+
+  dbl::comm::reorder_to_bf16_for_mix_prec(grad_output);
+  dbl::comm::reorder_to_bf16_for_mix_prec(output);
+
   dil::tensor y = dbl::comm::try_gen_dil_tensor(output);
   auto grad_output_contiguous = grad_output.is_contiguous() ? grad_output : grad_output.contiguous();
   dil::tensor gy = dbl::comm::try_gen_dil_tensor(grad_output_contiguous);
@@ -1125,6 +1321,9 @@ at::Tensor AtenIpexCPUDev::dil_sigmoid_backward(
 at::Tensor AtenIpexCPUDev::dil_reshape(const at::Tensor& self, at::IntArrayRef size) {
   DEBUG("AtenIpexCPUDev::dil_reshape\n");
   CHECK_DNNL_OP_PRE_COND(self);
+
+  dbl::comm::reorder_to_bf16_for_mix_prec(self);
+
   auto inferred_size = at::infer_size(size, self.numel());
   if (self.sizes() == inferred_size) {
     return self;
@@ -1138,6 +1337,9 @@ at::Tensor AtenIpexCPUDev::dil_reshape(const at::Tensor& self, at::IntArrayRef s
 at::Tensor AtenIpexCPUDev::dil_clone(const at::Tensor& self, c10::optional<c10::MemoryFormat> optional_memory_format) {
   DEBUG("AtenIpexCPUDev::dil_clone\n");
   CHECK_DNNL_OP_PRE_COND(self);
+
+  dbl::comm::reorder_to_bf16_for_mix_prec(self);
+
   TORCH_CHECK(
       !optional_memory_format.has_value(),
       "unsupported memory format option ",
@@ -1151,6 +1353,9 @@ at::Tensor AtenIpexCPUDev::dil_clone(const at::Tensor& self, c10::optional<c10::
 at::Tensor AtenIpexCPUDev::dil_transpose(const at::Tensor & self, int64_t dim0, int64_t dim1) {
   DEBUG("AtenIpexCPUDev::dil_transpose\n");
   CHECK_DNNL_OP_PRE_COND(self);
+
+  dbl::comm::reorder_to_bf16_for_mix_prec(self);
+
   dil::tensor x = dbl::comm::try_gen_dil_tensor(self);
   TORCH_CHECK(x.ndims() > 0, "DNNL transpose cannot generate DNNL tensor for the input aten Tensor. input tensor dim: ", self.dim());
   dil::tensor y;
@@ -1174,12 +1379,18 @@ inline void check_cat_no_zero_dim(at::TensorList tensors) {
 at::Tensor& AtenIpexCPUDev::dil_cat_out(at::Tensor& result, at::TensorList tensors, int64_t dim) {
   DEBUG("AtenIpexCPUDev::dil_cat_out\n");
   CHECK_DNNL_OP_PRE_COND(result);
+
+  dbl::comm::reorder_to_bf16_for_mix_prec(result);
+
   check_cat_no_zero_dim(tensors);
   dim = at::legacy_cat_wrap_dim(dim, tensors);
   std::vector<dil::tensor> x;
   for (auto i =0; i< tensors.size(); i++) {
     TORCH_CHECK(!(tensors[i].dim() == 1 && tensors[i].sizes()[0] == 0),
       "Currently Mkldnn cat operators do not support empty tensor.");
+
+    dbl::comm::reorder_to_bf16_for_mix_prec(tensors[i]);
+
     x.push_back(dbl::comm::try_gen_dil_tensor(tensors[i]));
   }
   dil::tensor y = dbl::comm::try_gen_dil_tensor(result);
@@ -1200,6 +1411,7 @@ at::Tensor AtenIpexCPUDev::dil_cat(at::TensorList tensors, int64_t dim) {
     TORCH_CHECK(!(tensors[i].dim() == 1 && tensors[i].sizes()[0] == 0),
       "Currently Mkldnn cat operators do not support empty tensor.");
     tensors_contiguous[i] = tensors[i].is_contiguous() ? tensors[i] : tensors[i].contiguous();
+    dbl::comm::reorder_to_bf16_for_mix_prec(tensors_contiguous[i]);
     x.push_back(dbl::comm::try_gen_dil_tensor(tensors_contiguous[i]));
   }
   dil::tensor y;
@@ -1210,6 +1422,9 @@ at::Tensor AtenIpexCPUDev::dil_cat(at::TensorList tensors, int64_t dim) {
 std::vector<at::Tensor> AtenIpexCPUDev::dil_split_with_sizes(const at::Tensor& self, at::IntArrayRef split_sizes, int64_t dim) {
   DEBUG("AtenIpexCPUDev::dil_split_with_sizes\n");
   CHECK_DNNL_OP_PRE_COND(self);
+
+  dbl::comm::reorder_to_bf16_for_mix_prec(self);
+
   dil::tensor x = dbl::comm::try_gen_dil_tensor(self);
   int64_t num_splits = split_sizes.size();
   std::vector<at::Tensor> splits(num_splits);

--- a/torch_ipex/csrc/cpu/DevOPs.cpp
+++ b/torch_ipex/csrc/cpu/DevOPs.cpp
@@ -1183,6 +1183,9 @@ at::Tensor AtenIpexCPUDev::dil_relu(const at::Tensor& input) {
 at::Tensor& AtenIpexCPUDev::dil_relu_(at::Tensor& input) {
   DEBUG("AtenIpexCPUDev::dil_relu_\n");
   CHECK_DNNL_OP_PRE_COND(input);
+
+  dbl::comm::reorder_to_bf16_for_mix_prec(input);
+
   auto dil_self = dbl::comm::try_gen_dil_tensor(input);
   dil::eltwise_forward::compute(
     dil_self,

--- a/torch_ipex/csrc/cpu/ShadeDataContext.h
+++ b/torch_ipex/csrc/cpu/ShadeDataContext.h
@@ -13,25 +13,35 @@ namespace cpu {
 
 enum SHADE_DATA_TYPE {CPU_RAW, DIL};
 
+enum MIX_PREC_TYPE {NONE, MIX_BF_FP32};
+
 struct ShadeDataContext {
   c10::optional<dil::tensor> dil_tensor; ///< DNNL memory buffer for lazy reorder
   void              *cpu_raw_data; ///< The raw memory buffer of storage
   c10::DeleterFnPtr  cpu_del_fun;  ///< Delete function to release cpu_raw_data
 
   SHADE_DATA_TYPE    data_type;    ///< Memory buffer type
+  MIX_PREC_TYPE      mix_prec_type; ///< Record if the aten tensor is mix-precision
 
   ShadeDataContext() : dil_tensor(),
                        cpu_raw_data(nullptr),
                        cpu_del_fun(nullptr),
-                       data_type(SHADE_DATA_TYPE::CPU_RAW) {}
+                       data_type(SHADE_DATA_TYPE::CPU_RAW),
+                       mix_prec_type(MIX_PREC_TYPE::NONE) {}
 
   ~ShadeDataContext() {
     if (this->data_type == SHADE_DATA_TYPE::DIL) { // DIL Tensor
       TORCH_INTERNAL_ASSERT_DEBUG_ONLY(this->dil_tensor.has_value());
       if (this->dil_tensor->is_public_format()) {
-        TORCH_INTERNAL_ASSERT_DEBUG_ONLY(this->cpu_raw_data != nullptr);
-        TORCH_INTERNAL_ASSERT_DEBUG_ONLY(this->dil_tensor->get_data_handle() == this->cpu_raw_data);
-        TORCH_INTERNAL_ASSERT_DEBUG_ONLY(this->cpu_del_fun == &(c10::detail::deleteNothing));
+        if (this->mix_prec_type == MIX_PREC_TYPE::MIX_BF_FP32) {
+          TORCH_INTERNAL_ASSERT_DEBUG_ONLY(this->cpu_raw_data == nullptr);
+          TORCH_INTERNAL_ASSERT_DEBUG_ONLY(this->dil_tensor->get_data_handle() != this->cpu_raw_data);
+          TORCH_INTERNAL_ASSERT_DEBUG_ONLY(this->cpu_del_fun == nullptr);
+        } else {
+          TORCH_INTERNAL_ASSERT_DEBUG_ONLY(this->cpu_raw_data != nullptr);
+          TORCH_INTERNAL_ASSERT_DEBUG_ONLY(this->dil_tensor->get_data_handle() == this->cpu_raw_data);
+          TORCH_INTERNAL_ASSERT_DEBUG_ONLY(this->cpu_del_fun == &(c10::detail::deleteNothing));
+        }
       } else {
         // If dil tensor is block format, the cpu raw data means nothing here.
         TORCH_INTERNAL_ASSERT_DEBUG_ONLY(this->cpu_raw_data == nullptr);
@@ -47,7 +57,7 @@ struct ShadeDataContext {
 
   /**
    * The deleter function to release @class ShadeDataContext
-   * 
+   *
    * @param raw_data Raw pointer of @class ShadeDataContext
    */
   static void freeShadeDataContext(void *raw_data) {
@@ -68,9 +78,9 @@ struct ShadeDataContext {
 
   /**
    * Check the buffer of aten tensor is DNNL buffer or raw CPU buffer
-   * 
+   *
    * @param tensor input aten tensor
-   * 
+   *
    * @note If the storage contains both DNNL buffer and CPU buffer, and the DNNL buffer shares
    * all data with CPU buffer, then the tensor is DNNL tensor. Besides that if current storage
    * only contains DNNL buffer, it obiviouly is DNNL tensor
@@ -127,18 +137,18 @@ struct ShadeDataContext {
 
   /**
    * Check if the input tensor only contains CPU buffer.
-   * 
+   *
    * @param tensor input aten tensor
    */
   static inline bool isCpuTensor(const at::Tensor &tensor) {
-    return !isDilTensor(tensor);
+    return !isDilOwnTheTensor(tensor);
   }
 
   /**
    * Unpack DNNL buffer from the input tensor
-   * 
+   *
    * @param tensor input aten tensor
-   * 
+   *
    * @return If the input tensor does not contain DNNL buffer, the function will return
    * an empty DNNL buffer. The caller should check the return buffer is empty or not.
    */
@@ -154,9 +164,9 @@ struct ShadeDataContext {
 
   /**
    * Unpack raw CPU buffer from the input tensor
-   * 
+   *
    * @param tensor input aten tensor
-   * 
+   *
    * @return If the input tensor contains CPU buffer, the buffer will be unpacked from @class ShadeDataContext
    * and return it to the caller. Otherwise, the function will return nullptr
    */
@@ -173,6 +183,34 @@ struct ShadeDataContext {
       return nullptr;
     }
   }
+
+  /**
+   * Check if the buffer of input tensor is owned by DNNL.
+   *
+   * @param tensor input aten tensor
+   */
+  static inline bool isDilOwnTheTensor(const at::Tensor &tensor) {
+    void *storage_context = tensor.storage().data_ptr().get_context();
+    ShadeDataContext *shade_data_context = (ShadeDataContext*)storage_context;
+    auto data_type = shade_data_context->data_type;
+    TORCH_INTERNAL_ASSERT_DEBUG_ONLY((data_type == SHADE_DATA_TYPE::CPU_RAW) || (data_type == SHADE_DATA_TYPE::DIL));
+    return data_type == SHADE_DATA_TYPE::DIL;
+  }
+
+
+  /**
+   * Check if the data type of dnnl buffer is as same as the data type of aten tensor.
+   *
+   * @param tensor input aten tensor
+   */
+  static inline bool isTensorMixPrecision(const at::Tensor &tensor) {
+    auto dil_tensor_type = getDilTensor(tensor).get_data_type();
+    auto aten_tensor_type = tensor.scalar_type();
+    TORCH_INTERNAL_ASSERT_DEBUG_ONLY(aten_tensor_type == at::kFloat);
+    TORCH_INTERNAL_ASSERT_DEBUG_ONLY(dil_tensor_type == dil::data_type::bf16 || dil_tensor_type == dil::data_type::f32);
+    return dil_tensor_type == dil::data_type::bf16 && aten_tensor_type == at::kFloat;
+  }
+
 };
 
 }  // namespace cpu

--- a/torch_ipex/csrc/cpu/ShadeDataContext.h
+++ b/torch_ipex/csrc/cpu/ShadeDataContext.h
@@ -15,6 +15,30 @@ enum SHADE_DATA_TYPE {CPU_RAW, DIL};
 
 enum MIX_PREC_TYPE {NONE, MIX_BF_FP32};
 
+#define SANITY_CHECK_SHADE_DATA_CONTEXT(THIS) \
+  { \
+    if (THIS->data_type == SHADE_DATA_TYPE::DIL) { \
+      TORCH_INTERNAL_ASSERT_DEBUG_ONLY(THIS->dil_tensor.has_value()); \
+      if (THIS->dil_tensor->is_public_format()) { \
+        if (THIS->mix_prec_type == MIX_PREC_TYPE::MIX_BF_FP32) { \
+          TORCH_INTERNAL_ASSERT_DEBUG_ONLY(THIS->cpu_raw_data == nullptr); \
+          TORCH_INTERNAL_ASSERT_DEBUG_ONLY(THIS->dil_tensor->get_data_handle() != THIS->cpu_raw_data); \
+          TORCH_INTERNAL_ASSERT_DEBUG_ONLY(THIS->cpu_del_fun == nullptr); \
+        } else { \
+          TORCH_INTERNAL_ASSERT_DEBUG_ONLY(THIS->cpu_raw_data != nullptr); \
+          TORCH_INTERNAL_ASSERT_DEBUG_ONLY(THIS->dil_tensor->get_data_handle() == THIS->cpu_raw_data); \
+          TORCH_INTERNAL_ASSERT_DEBUG_ONLY(THIS->cpu_del_fun == &(c10::detail::deleteNothing)); \
+        } \
+      } else { \
+        TORCH_INTERNAL_ASSERT_DEBUG_ONLY(THIS->cpu_raw_data == nullptr); \
+        TORCH_INTERNAL_ASSERT_DEBUG_ONLY(THIS->cpu_del_fun == nullptr); \
+      } \
+    } else { \
+      TORCH_INTERNAL_ASSERT_DEBUG_ONLY(THIS->cpu_del_fun != nullptr); \
+      TORCH_INTERNAL_ASSERT_DEBUG_ONLY(THIS->cpu_del_fun != &(c10::detail::deleteNothing)); \
+    } \
+  }
+
 struct ShadeDataContext {
   c10::optional<dil::tensor> dil_tensor; ///< DNNL memory buffer for lazy reorder
   void              *cpu_raw_data; ///< The raw memory buffer of storage
@@ -30,26 +54,8 @@ struct ShadeDataContext {
                        mix_prec_type(MIX_PREC_TYPE::NONE) {}
 
   ~ShadeDataContext() {
-    if (this->data_type == SHADE_DATA_TYPE::DIL) { // DIL Tensor
-      TORCH_INTERNAL_ASSERT_DEBUG_ONLY(this->dil_tensor.has_value());
-      if (this->dil_tensor->is_public_format()) {
-        if (this->mix_prec_type == MIX_PREC_TYPE::MIX_BF_FP32) {
-          TORCH_INTERNAL_ASSERT_DEBUG_ONLY(this->cpu_raw_data == nullptr);
-          TORCH_INTERNAL_ASSERT_DEBUG_ONLY(this->dil_tensor->get_data_handle() != this->cpu_raw_data);
-          TORCH_INTERNAL_ASSERT_DEBUG_ONLY(this->cpu_del_fun == nullptr);
-        } else {
-          TORCH_INTERNAL_ASSERT_DEBUG_ONLY(this->cpu_raw_data != nullptr);
-          TORCH_INTERNAL_ASSERT_DEBUG_ONLY(this->dil_tensor->get_data_handle() == this->cpu_raw_data);
-          TORCH_INTERNAL_ASSERT_DEBUG_ONLY(this->cpu_del_fun == &(c10::detail::deleteNothing));
-        }
-      } else {
-        // If dil tensor is block format, the cpu raw data means nothing here.
-        TORCH_INTERNAL_ASSERT_DEBUG_ONLY(this->cpu_raw_data == nullptr);
-        TORCH_INTERNAL_ASSERT_DEBUG_ONLY(this->cpu_del_fun == nullptr);
-      }
-    } else { // CPU Tensor here
-      TORCH_INTERNAL_ASSERT_DEBUG_ONLY(this->cpu_del_fun != nullptr);
-      TORCH_INTERNAL_ASSERT_DEBUG_ONLY(this->cpu_del_fun != &(c10::detail::deleteNothing));
+    SANITY_CHECK_SHADE_DATA_CONTEXT(this);
+    if (this->data_type == SHADE_DATA_TYPE::CPU_RAW) { // CPU Tensor here
       this->cpu_del_fun(this->cpu_raw_data);
       this->cpu_raw_data = nullptr;
     }
@@ -101,14 +107,12 @@ struct ShadeDataContext {
     auto data_type = shade_data_context->data_type;
     TORCH_INTERNAL_ASSERT_DEBUG_ONLY((data_type == SHADE_DATA_TYPE::CPU_RAW) || (data_type == SHADE_DATA_TYPE::DIL));
 
+    SANITY_CHECK_SHADE_DATA_CONTEXT(shade_data_context);
+
     if (data_type == SHADE_DATA_TYPE::DIL) {
-      TORCH_INTERNAL_ASSERT_DEBUG_ONLY(shade_data_context->dil_tensor.has_value());
       auto raw_cpu_data = tensor.storage().data_ptr().get();
       if (raw_cpu_data == nullptr) {
         // the dnnl tensor does not share data with raw tensor data.
-        TORCH_INTERNAL_ASSERT_DEBUG_ONLY(! (shade_data_context->dil_tensor->is_empty()));
-        TORCH_INTERNAL_ASSERT_DEBUG_ONLY(! (shade_data_context->dil_tensor->is_public_format()));
-        TORCH_INTERNAL_ASSERT_DEBUG_ONLY(check_tensor_own_whole_storage(tensor));
         return true;
       } else {
         // The dnnl tensor shares some data with raw tensor.
@@ -206,9 +210,20 @@ struct ShadeDataContext {
   static inline bool isTensorMixPrecision(const at::Tensor &tensor) {
     auto dil_tensor_type = getDilTensor(tensor).get_data_type();
     auto aten_tensor_type = tensor.scalar_type();
-    TORCH_INTERNAL_ASSERT_DEBUG_ONLY(aten_tensor_type == at::kFloat);
+    TORCH_INTERNAL_ASSERT_DEBUG_ONLY(aten_tensor_type == at::kFloat || aten_tensor_type == at::kBFloat16);
     TORCH_INTERNAL_ASSERT_DEBUG_ONLY(dil_tensor_type == dil::data_type::bf16 || dil_tensor_type == dil::data_type::f32);
-    return dil_tensor_type == dil::data_type::bf16 && aten_tensor_type == at::kFloat;
+    auto res = dil_tensor_type == dil::data_type::bf16 && aten_tensor_type == at::kFloat;
+
+    // Check mix_precision
+    void *raw_context = tensor.storage().data_ptr().get_context();
+    ShadeDataContext *shade_data_context = (ShadeDataContext*)raw_context;
+    if (shade_data_context->mix_prec_type == MIX_PREC_TYPE::MIX_BF_FP32) {
+      TORCH_INTERNAL_ASSERT_DEBUG_ONLY(res);
+    } else {
+      TORCH_INTERNAL_ASSERT_DEBUG_ONLY(!res);
+    }
+
+    return res;
   }
 
 };

--- a/torch_ipex/csrc/cpu/dbl/Common.cpp
+++ b/torch_ipex/csrc/cpu/dbl/Common.cpp
@@ -57,7 +57,7 @@ dil::tensor try_gen_dil_tensor(const at::Tensor &input) {
 at::Tensor gen_aten_tensor_by(dil::tensor&& dil_tensor) {
   // Generate new CPU Tensor and store dil tensor at its storage
   cpu::ShadeDataContext *shade_data_context = cpu::ShadeDataContext::allocShadeDataContext();
-  auto dil_tensor_type = shade_data_context->dil_tensor->get_data_type();
+  auto dil_tensor_type = dil_tensor.get_data_type();
   shade_data_context->dil_tensor = std::forward<dil::tensor>(dil_tensor);
   shade_data_context->data_type = cpu::SHADE_DATA_TYPE::DIL;
 
@@ -66,6 +66,7 @@ at::Tensor gen_aten_tensor_by(dil::tensor&& dil_tensor) {
   if (check_auto_mix_bf16_fp32() && dil_tensor_type == dil::data_type::bf16) {
     // If the user enables auto-mix-precision, then the aten tensor should always be float.
     // And even the dil tensor is plain format, it also cannot be shared with cpu buffer.
+    shade_data_context->mix_prec_type = cpu::MIX_PREC_TYPE::MIX_BF_FP32;
     at_data_type = at::kFloat;
   } else {
     if (shade_data_context->dil_tensor->is_public_format()) {

--- a/torch_ipex/csrc/cpu/dbl/Common.cpp
+++ b/torch_ipex/csrc/cpu/dbl/Common.cpp
@@ -6,6 +6,7 @@
 
 #include "cpu/dil/dil_pin_singletons.hpp"
 #include "cpu/ShadeDataContext.h"
+#include "torch_ipex/csrc/aten_ipex_bridge.h"
 #include "torch_ipex/csrc/ipex_tensor_impl.h"
 #include "torch_ipex/csrc/utils.h"
 #include "torch_ipex/csrc/auto_opt_config.h"
@@ -34,6 +35,11 @@ at::Tensor dil_tensor_to_dense(const at::Tensor& tensor) {
   return cpu_tensor;
 }
 
+void reorder_to_bf16_for_mix_prec(const at::Tensor& tensor) {
+  if (check_auto_mix_bf16_fp32())
+    bridge::reorderTensorToScalarTypeForDNNL(tensor, at::kBFloat16);
+}
+
 dil::tensor try_gen_dil_tensor(const at::Tensor &input) {
   if (cpu::ShadeDataContext::isDilTensor(input)) {
     auto dil_tensor = cpu::ShadeDataContext::getDilTensor(input);
@@ -51,21 +57,30 @@ dil::tensor try_gen_dil_tensor(const at::Tensor &input) {
 at::Tensor gen_aten_tensor_by(dil::tensor&& dil_tensor) {
   // Generate new CPU Tensor and store dil tensor at its storage
   cpu::ShadeDataContext *shade_data_context = cpu::ShadeDataContext::allocShadeDataContext();
+  auto dil_tensor_type = shade_data_context->dil_tensor->get_data_type();
   shade_data_context->dil_tensor = std::forward<dil::tensor>(dil_tensor);
   shade_data_context->data_type = cpu::SHADE_DATA_TYPE::DIL;
+
   void *tensor_data = nullptr;
-  if (shade_data_context->dil_tensor->is_public_format()) {
-    // The buffer of a tensor with public format is shared between CPU and DNNL
-    tensor_data = shade_data_context->dil_tensor->get_data_handle();
-    shade_data_context->cpu_raw_data = shade_data_context->dil_tensor->get_data_handle();
-    shade_data_context->cpu_del_fun = &(c10::detail::deleteNothing);
+  auto at_data_type = get_at_data_type(dil_tensor_type);
+  if (check_auto_mix_bf16_fp32() && dil_tensor_type == dil::data_type::bf16) {
+    // If the user enables auto-mix-precision, then the aten tensor should always be float.
+    // And even the dil tensor is plain format, it also cannot be shared with cpu buffer.
+    at_data_type = at::kFloat;
+  } else {
+    if (shade_data_context->dil_tensor->is_public_format()) {
+      // The buffer of a tensor with public format is shared between CPU and DNNL
+      tensor_data = shade_data_context->dil_tensor->get_data_handle();
+      shade_data_context->cpu_raw_data = shade_data_context->dil_tensor->get_data_handle();
+      shade_data_context->cpu_del_fun = &(c10::detail::deleteNothing);
+    }
   }
+
   c10::DataPtr shade_data_ptr(
     tensor_data,
     shade_data_context,
     cpu::ShadeDataContext::freeShadeDataContext,
     at::DeviceType::DPCPP);
-  auto at_data_type = get_at_data_type(shade_data_context->dil_tensor->get_data_type());
   auto storage_impl = c10::make_intrusive<at::StorageImpl>(
     at::scalarTypeToTypeMeta(at_data_type),
     shade_data_context->dil_tensor->get_nelems(),

--- a/torch_ipex/csrc/cpu/dbl/Common.h
+++ b/torch_ipex/csrc/cpu/dbl/Common.h
@@ -11,6 +11,7 @@ namespace comm {
 
 dil::tensor dil_tensor_from_dense(const at::Tensor& tensor);
 at::Tensor dil_tensor_to_dense(const at::Tensor& tensor);
+void reorder_to_bf16_for_mix_prec(const at::Tensor& tensor);
 dil::tensor try_gen_dil_tensor(const at::Tensor &input);
 at::Tensor gen_aten_tensor_by(dil::tensor&& tensor);
 at::Tensor empty_dil_tensor(at::IntArrayRef sizes, const at::TensorOptions& options);

--- a/torch_ipex/csrc/init_python_bindings.cpp
+++ b/torch_ipex/csrc/init_python_bindings.cpp
@@ -43,6 +43,24 @@ bool isDilTensor(const at::Tensor &tensor) {
   return cpu::ShadeDataContext::isDilTensor(tensor);
 }
 
+bool isBF16DilTensor(const at::Tensor &tensor) {
+  if (isDilTensor(tensor)) {
+    auto dil_tensor = cpu::ShadeDataContext::getDilTensor(tensor);
+    return dil_tensor.get_data_type() == dil::data_type::bf16;
+  }
+
+  return false;
+}
+
+bool isFP32DilTensor(const at::Tensor &tensor) {
+  if (isDilTensor(tensor)) {
+    auto dil_tensor = cpu::ShadeDataContext::getDilTensor(tensor);
+    return dil_tensor.get_data_type() == dil::data_type::f32;
+  }
+
+  return false;
+}
+
 dil::dims getDilTensorSizes(const at::Tensor &tensor) {
   if (isDilTensor(tensor)) {
     auto dil_tensor = cpu::ShadeDataContext::getDilTensor(tensor);
@@ -136,6 +154,8 @@ void InitIpexModuleBindings(py::module m) {
   m.def("mlp_set_relu_mask", &AtenIpexTypeMLPExt::set_relu_mask);
   m.def("mlp_release_handle", &AtenIpexTypeMLPExt::release_handle);
   m.def("is_dil_tensor", &isDilTensor);
+  m.def("is_bf16_dil_tensor", &isBF16DilTensor);
+  m.def("is_fp32_dil_tensor", &isFP32DilTensor);
   m.def("get_dil_tensor_sizes", &getDilTensorSizes);
   m.def("get_dil_tensor_strides", &getDilTensorStrides);
   m.def("enable_jit", []() { AutoOptConfig::singleton().set_jit_fuse(true); });

--- a/torch_ipex/csrc/utils.cpp
+++ b/torch_ipex/csrc/utils.cpp
@@ -106,6 +106,10 @@ bool check_auto_dnnl() {
   return AutoOptConfig::singleton().get_auto_dnnl();
 }
 
+bool check_auto_mix_bf16_fp32() {
+  return AutoOptConfig::singleton().get_mix_bf16_fp32();
+}
+
 bool check_tensor_own_whole_storage(const at::Tensor& tensor) {
   if (!(tensor.defined()))
     return false;

--- a/torch_ipex/csrc/utils.h
+++ b/torch_ipex/csrc/utils.h
@@ -18,6 +18,7 @@ bool get_device_count(c10::Device dev_type, c10::DeviceIndex *count);
 dil::data_type get_dil_data_type(at::ScalarType);
 at::ScalarType get_at_data_type(dil::data_type);
 bool check_auto_dnnl();
+bool check_auto_mix_bf16_fp32();
 bool check_tensor_own_whole_storage(const at::Tensor& tensor);
 bool check_tensor_own_shade_context(const at::Tensor& tensor);
 bool check_aten_dil_shape_info(const at::Tensor& ipex_tensor, const dil::tensor &dil_tensor);


### PR DESCRIPTION
We currently hide the BF16 data type in DNNL buffer and IPEX always represents the tensor as Float32. If the OP supports BFloat16, IPEX will reorder the buffer to BFloat16 and attach the bf16 buffer to the aten tensor. However, it still is in-place reorder, there might be issues for multi-instances inference.

@pinzhenx , could you help to check the correctness of the DNNL OPs in DevOPs? I will add more unit test cases.