### PR TITLE
Override tensor copy to support deepcopy

### DIFF
--- a/intel_pytorch_extension_py/__init__.py
+++ b/intel_pytorch_extension_py/__init__.py
@@ -1,6 +1,7 @@
 import os
 import torch
 from .version import __version__
+from .tensor import *
 from .optim import *
 from .ops import *
 import _torch_ipex as core

--- a/intel_pytorch_extension_py/tensor.py
+++ b/intel_pytorch_extension_py/tensor.py
@@ -1,11 +1,13 @@
 import torch
 
+org_tensor_deep_copy = torch.Tensor.__deepcopy__
+
 def __ipex_tensor_deepcopy__(self, memo):
     if self.device.type == 'dpcpp':
         with torch.no_grad():
             new_tensor = self.clone()
             return new_tensor
     else:
-        return self.__deepcopy__(memo)
+        return org_tensor_deep_copy(self, memo)
 
 torch.Tensor.__deepcopy__ = __ipex_tensor_deepcopy__

--- a/intel_pytorch_extension_py/tensor.py
+++ b/intel_pytorch_extension_py/tensor.py
@@ -1,0 +1,11 @@
+import torch
+
+def __ipex_tensor_deepcopy__(self, memo):
+    if self.device.type == 'dpcpp':
+        with torch.no_grad():
+            new_tensor = self.clone()
+            return new_tensor
+    else:
+        return self.__deepcopy__(memo)
+
+torch.Tensor.__deepcopy__ = __ipex_tensor_deepcopy__


### PR DESCRIPTION
`copy.deepcopy` will trigger a check that the current backend supports the storage with the specified data type. But PyTorch only registers different data type storages for CPU and CUDA, so the check will fail. IPEX rewrites the `__deepcopy__` of tensor by `clone` to work around it.

@zhuhaozhe @pinzhenx @hongzhen1 