### PR TITLE
jit: enable prepack dnnl convolution's weight

### DIFF
--- a/tests/cpu/test_jit.py
+++ b/tests/cpu/test_jit.py
@@ -83,41 +83,6 @@ SIZE = 100
 torch._C._jit_set_profiling_mode(False)
 torch._C._jit_set_profiling_executor(False)
 
-def test_output(model, x):
-    modelName = model.__class__.__name__
-    core.disable_jit()
-
-    model = model.to('dpcpp').eval()
-    x = x.to('dpcpp')
-    with torch.no_grad():
-        result = model(x)
-
-    smodel = torch.jit.script(model)
-    smodel.eval()
-    with torch.no_grad():
-        sresult = smodel(x)
-
-    print(f'\nAre {modelName} and Scripted{modelName} outputs the same: ',
-          torch.allclose(
-              sresult, result, rtol=1e-05, atol=1e-06, equal_nan=False))
-
-    core.enable_jit()
-    pmodel = torch.jit.script(model)
-    # bn folding
-    pmodel = wrap_cpp_module(torch._C._jit_pass_fold_convbn(pmodel._c))
-    with torch.no_grad():
-        # conv relu fusion, conv sum fusion or conv sum relu fusion
-        print(pmodel.graph_for(x))
-        presult = pmodel(x)
-
-    # print(result)
-    # print(sresult)
-    # print(presult)
-
-    print(f'\nWith or without pyrys, are Scripted{modelName} outputs the same: ',
-          torch.allclose(
-                sresult, presult, rtol=1e-05, atol=1e-06, equal_nan=False))
-
 class Conv2dRelu_Fixed(nn.Module):
     def __init__(self, in_channels, out_channels, **kwargs):
         super(Conv2dRelu_Fixed, self).__init__()
@@ -161,29 +126,59 @@ class LinearRelu(nn.Module):
         return F.relu(self.linear(x), inplace=True)
 
 class Tester(TestCase):
-    n = 32
-    c = 3
-    h = 224
-    w = 224
-    print('input size: (%d, %d, %d, %d)' % (n, c, h, w))
+
+    def _test_output(self, model, x):
+        modelName = model.__class__.__name__
+        core.disable_jit()
+
+        model = model.to('dpcpp').eval()
+        x = x.to('dpcpp')
+        with torch.no_grad():
+            result = model(x)
+
+        script_model = torch.jit.script(model)
+        script_model.eval()
+        with torch.no_grad():
+            sresult = script_model(x)
+
+        self.assertEqual(result, sresult)
+
+        core.enable_jit()
+        fused_model = torch.jit.script(model)
+        # bn folding, removing it after solve some issue
+        core.disable_auto_dnnl()
+        fused_model = wrap_cpp_module(torch._C._jit_pass_fold_convbn(fused_model._c))
+        core.enable_auto_dnnl()
+        # prepack convolution weight
+        fused_model = wrap_cpp_module(core._jit_prepack_conv_weight(fused_model._c))
+        with torch.no_grad():
+            # conv relu fusion, conv sum fusion or conv sum relu fusion
+            print(fused_model.graph_for(x))
+            fresult = fused_model(x)
+
+        # print(result)
+        # print(sresult)
+        # print(fresult)
+
+        self.assertEqual(result, fresult)
 
     def test_output_conv_relu(self):
-        test_output(
-            Conv2dRelu_Fixed(self.c, 32, kernel_size=3, stride=1),
-            torch.rand(self.n, self.c, self.h, self.w))
+        self._test_output(
+            Conv2dRelu_Fixed(3, 32, kernel_size=3, stride=1),
+            torch.randn(32, 3, 224, 224))
 
     def test_output_cascaded_conv2d_bn_sum_relu(self):
-        test_output(
-            CascadedConv2dBnSumRelu(self.c, 64, 32, kernel_size=3, stride=1),
-            torch.rand(self.n, self.c, self.h, self.w))
+        self._test_output(
+            CascadedConv2dBnSumRelu(3, 64, 32, kernel_size=3, stride=1),
+            torch.rand(32, 3, 224, 224))
 
     def test_output_linear_relu(self):
-        test_output(
-            LinearRelu(self.c, 32, bias=True),
-            torch.rand(self.n, self.c))
-        test_output(
-            LinearRelu(self.c, 32, bias=False),
-            torch.rand(self.n, self.c))
+        self._test_output(
+            LinearRelu(3, 32, bias=True),
+            torch.rand(32, 3))
+        self._test_output(
+            LinearRelu(3, 32, bias=False),
+            torch.rand(32, 3))
 
 if __name__ == '__main__':
     core.enable_auto_dnnl()

--- a/torch_ipex/csrc/cpu/Prepack.cpp
+++ b/torch_ipex/csrc/cpu/Prepack.cpp
@@ -8,7 +8,7 @@ namespace torch_ipex {
 using namespace cpu::dbl::comm;
 
 void AtenIpexPrepack::prepack_conv_weight(
-    at::Tensor &weight,
+    at::Tensor& weight,
     at::IntArrayRef padding,
     at::IntArrayRef stride,
     at::IntArrayRef dilation,
@@ -34,4 +34,35 @@ void AtenIpexPrepack::prepack_conv_weight(
   bridge::reorderDilTensorGeneric(weight, packed_desc);
 }
 
+at::Tensor AtenIpexJITPrepack::prepack_conv_weight(
+    const at::Tensor& weight,
+    at::IntArrayRef padding,
+    at::IntArrayRef stride,
+    at::IntArrayRef dilation,
+    int64_t groups) {
+  TORCH_CHECK(weight.device().type() == at::DeviceType::DPCPP,
+              "Cannot prepack a non-dpcpp tensor. Call t.to('dpcpp') first.");
+
+  auto kdims = weight.dim() - 2;
+  auto stride_vec = expand_param_if_needed(stride, "stride", kdims);
+  auto padding_vec = expand_param_if_needed(padding, "padding", kdims);
+  auto dilation_vec = expand_param_if_needed(dilation, "dilation", kdims);
+
+  auto packed_desc =
+      dil::convolution_forward::expected_weights_desc(
+          weight.sizes().vec(),
+          torch_ipex::get_dil_data_type(weight.scalar_type()),
+          stride_vec,
+          padding_vec,
+          padding_vec,
+          dilation_vec,
+          groups);
+
+  dil::tensor src = cpu::dbl::comm::try_gen_dil_tensor(weight);
+  dil::tensor dst{packed_desc};
+  dst.feed_from(src);
+  return gen_aten_tensor_by(std::move(dst));
+}
+
 }  // namespace torch_ipex
+

--- a/torch_ipex/csrc/cpu/Prepack.h
+++ b/torch_ipex/csrc/cpu/Prepack.h
@@ -9,4 +9,10 @@ class AtenIpexPrepack {
   static void prepack_conv_weight(at::Tensor &weight, at::IntArrayRef padding, at::IntArrayRef stride, at::IntArrayRef dilation, int64_t groups);
 };
 
+class AtenIpexJITPrepack {
+ public:
+  static at::Tensor prepack_conv_weight(const at::Tensor &weight, at::IntArrayRef padding, at::IntArrayRef stride, at::IntArrayRef dilation, int64_t groups);
+};
+
 }  // namespace torch_ipex
+

--- a/torch_ipex/csrc/init_python_bindings.cpp
+++ b/torch_ipex/csrc/init_python_bindings.cpp
@@ -10,6 +10,7 @@
 #include <torch/csrc/jit/runtime/operator_options.h>
 #include <torch/csrc/jit/passes/pass_manager.h>
 #include "jit/fusion_pass.h"
+#include "jit/prepack_weight.h"
 
 #include <cstring>
 #include <sstream>
@@ -162,6 +163,7 @@ void InitIpexModuleBindings(py::module m) {
   m.def("disable_jit", []() { AutoOptConfig::singleton().set_jit_fuse(false); });
   m.def("get_jit", []() { return AutoOptConfig::singleton().get_jit_fuse(); });
   m.def("prepack_conv_weight", &AtenIpexPrepack::prepack_conv_weight);
+  m.def("_jit_prepack_conv_weight", &torch::jit::prepack_conv_weight);
 }
 
 }  // namespace

--- a/torch_ipex/csrc/jit/CMakeLists.txt
+++ b/torch_ipex/csrc/jit/CMakeLists.txt
@@ -1,6 +1,7 @@
 LIST(APPEND DPCPP_JIT_SRCS
     ${DPCPP_ROOT}/jit/fusion_pass.cpp
     ${DPCPP_ROOT}/jit/register_dnnl_jit_ops.cpp
+    ${DPCPP_ROOT}/jit/prepack_weight.cpp
 
 )
 

--- a/torch_ipex/csrc/jit/prepack_weight.cpp
+++ b/torch_ipex/csrc/jit/prepack_weight.cpp
@@ -1,0 +1,162 @@
+#include <torch/csrc/jit/ir/ir.h>
+#include <torch/csrc/jit/ir/irparser.h>
+#include <torch/csrc/jit/api/module.h>
+#include <torch/csrc/jit/ir/subgraph_matcher.h>
+#include <torch/csrc/jit/jit_log.h>
+#include <ATen/core/functional.h> 
+
+#include <stack>
+
+#include "cpu/Prepack.h"
+
+namespace torch {
+namespace jit {
+
+namespace {
+
+struct ConvParameters {
+  at::Tensor conv_w;
+  std::vector<int64_t> conv_s;
+  std::vector<int64_t> conv_p;
+  std::vector<int64_t> conv_d;
+  int64_t conv_g;
+};
+
+static inline bool hastensor(Module& m, const char* name) {
+  return m.hasattr(name) && m.attr(name).isTensor();
+}
+
+static inline bool hastuple(Module& m, const char* name) {
+  return m.hasattr(name) && m.attr(name).isTuple();
+}
+
+static inline bool hasint(Module& m, const char* name) {
+  return m.hasattr(name) && m.attr(name).isInt();
+}
+
+static inline std::vector<int64_t> tupleToIntList(const IValue& v) {
+  return fmap(v.toTuple()->elements(), [](const IValue& v) -> int64_t {
+    return v.toInt();
+  });
+}
+
+class PrepackConvWeightHelper {
+  public:
+    void analyze(Module& module);
+    void transform();
+  private:
+    bool tryExtractingConvParameters(
+      Module& conv,
+      ConvParameters& r);
+    
+    at::Tensor computeUpdatedConvWeight(const ConvParameters& p);
+    std::unordered_map<ModulePtr, at::Tensor> conv_module_and_params_;
+    std::unordered_map<Graph*, std::vector<std::string>> conv_names_;
+};
+
+bool PrepackConvWeightHelper::tryExtractingConvParameters(
+    Module& conv,
+    ConvParameters& r) {
+  if (!hastensor(conv, "weight") || !hastuple(conv, "stride") ||
+      !hastuple(conv, "padding") || !hastuple(conv, "dilation") ||
+      !hasint(conv, "groups")) {
+    return false;
+  }
+  r.conv_w = conv.attr("weight").toTensor();
+  r.conv_s = tupleToIntList(conv.attr("stride"));
+  r.conv_p = tupleToIntList(conv.attr("padding"));
+  r.conv_d = tupleToIntList(conv.attr("dilation"));
+  r.conv_g = conv.attr("groups").toInt();
+  return true;
+}
+
+at::Tensor PrepackConvWeightHelper::computeUpdatedConvWeight(const ConvParameters& p) {
+  at::Tensor new_w= torch_ipex::AtenIpexJITPrepack::prepack_conv_weight(
+      p.conv_w, p.conv_p, p.conv_s, p.conv_d, p.conv_g);
+  return new_w;
+}
+
+void PrepackConvWeightHelper::analyze(Module& module) {
+  std::string conv_R = R"(
+graph(%self, %x):
+    %conv_submodule = match::module[name="Conv2d"](%self)
+    %conv_out = prim::CallMethod[name="forward"](%conv_submodule, %x)
+    return (%conv_out))";
+
+  Graph pattern_graph;
+  std::unordered_map<std::string, Value*> vmap;
+  parseIR(conv_R, &pattern_graph, vmap);
+
+  Value* pattern_conv_out = vmap.at("conv_out");
+  Value* pattern_conv_submodule = vmap.at("conv_submodule");
+  Node* pattern_conv = pattern_conv_out->node();
+
+  std::stack<Module> worklist({module});
+  while (!worklist.empty()) {
+    Module current = worklist.top();
+    worklist.pop();
+
+    for (const Module& submodule : current.children()) {
+      worklist.push(submodule);
+    }
+
+    for (auto& method : current.get_methods()) {
+      GRAPH_DUMP(
+          current.type()->name()->name() + "::" + method.name() +
+          "() before Conv2d folding", method.graph());
+      const auto& matches = findPatternMatches(pattern_graph, *method.graph());
+      GRAPH_DEBUG("number of Conv2d matches: ", matches.size());
+      Graph* g = method.graph().get();
+      if (!conv_names_.count(g)) {
+        // This is to make sure we don't visit one graph multiple times
+        conv_names_[g] = {};
+        for (const Match& match : matches) {
+          GRAPH_DEBUG("Checking next match...");
+          Node* matched_conv = match.nodes_map.at(pattern_conv);
+          Node* matched_conv_submodule = match.values_map.at(pattern_conv_submodule)->node();
+
+          TORCH_INTERNAL_ASSERT(matched_conv_submodule->kind() == prim::GetAttr);
+          const auto& conv_module_name = matched_conv_submodule->s(Symbol::attr("name"));
+          Module conv_submodule = current.attr(conv_module_name).toModule();
+
+          ConvParameters params;
+          if (!tryExtractingConvParameters(conv_submodule, params)) {
+            GRAPH_DEBUG("Conv module didn't have all required parameters or attributes...");
+            continue;
+          }
+          conv_names_[g].push_back(conv_module_name); 
+        }
+      }
+
+      for (const auto& conv : conv_names_.at(g)) {
+        Module conv_submodule = current.attr(conv).toModule();
+        ConvParameters params;
+        TORCH_INTERNAL_ASSERT(tryExtractingConvParameters(conv_submodule, params));
+        auto new_w = computeUpdatedConvWeight(params);
+        conv_module_and_params_[conv_submodule._ivalue()] = new_w;
+      } // conv module
+    }
+  }
+}
+
+void PrepackConvWeightHelper::transform() {
+  for (const auto& item : conv_module_and_params_) {
+    Module conv(item.first);
+    auto w = item.second;
+    conv.setattr("weight", w);
+  }
+}
+
+} // namespace 
+
+Module prepack_conv_weight(const Module& module) {
+  PrepackConvWeightHelper h;
+  Module m = module.clone();
+  h.analyze(m);
+  h.transform();
+  return m;
+}
+
+} // namespace jit
+
+} // namespace torch

--- a/torch_ipex/csrc/jit/prepack_weight.h
+++ b/torch_ipex/csrc/jit/prepack_weight.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include <torch/csrc/jit/api/module.h>
+
+namespace torch{
+namespace jit{
+
+Module prepack_conv_weight(const Module& module);
+
+}
+
+}


### PR DESCRIPTION
For jit path, the users can prepack DNNL convolution's weight by following steps:
```
modle = MyModel().to('dpcpp").eval()
scripted= torch.jit.script(model)
scripted = wrap_cpp_module(core._jit_prepack_conv_weight(scripted._c))
```