### PR TITLE
force all inputs to be dpcpp tensor

### DIFF
--- a/intel_pytorch_extension_py/ops/__init__.py
+++ b/intel_pytorch_extension_py/ops/__init__.py
@@ -5,5 +5,4 @@ from .pooling import *
 from .reshape import *
 from .mlp import * 
 from .linear_fuse_relu import *
-from .module import *
 from .jit_script import *

--- a/tests/cpu/test_lazy_reorder.py
+++ b/tests/cpu/test_lazy_reorder.py
@@ -882,7 +882,7 @@ class TestTensorShape(TestCase):
             y = torch.randn(new_shape)
             out_cpu = x_cpu_view * y
             # test if the shape of x_dpcpp_view is compatible with y
-            out_dpcpp = x_dpcpp_view * y
+            out_dpcpp = x_dpcpp_view * y.to(device)
             self.assertTrue(ipex.is_dil_tensor(out_dpcpp))
             self.assertEqual(ipex.get_dil_tensor_sizes(out_dpcpp), [1, 4, 4, 4])
             self.assertEqual(ipex.get_dil_tensor_strides(out_dpcpp), [64, 16, 4, 1])

--- a/tests/cpu/test_lazy_reorder.py
+++ b/tests/cpu/test_lazy_reorder.py
@@ -13,6 +13,8 @@ import sys
 import torch
 import intel_pytorch_extension as ipex
 
+from common_ipex_conf import AutoMixPrecision, AutoDNNL
+
 import torch.nn as nn
 import torch.backends.cudnn as cudnn
 from torch.nn import Parameter

--- a/torch_ipex/csrc/cpu/dbl/DNNLChecker.cpp
+++ b/torch_ipex/csrc/cpu/dbl/DNNLChecker.cpp
@@ -9,7 +9,8 @@ namespace dbl {
 namespace chk {
 
 bool dnnl_support_the_tensors(const std::vector<at::Tensor> &tensor_vec) {
-  return dnnl_tensor_has_data(tensor_vec) &&
+  return all_is_dpcpp(tensor_vec) &&
+         dnnl_tensor_has_data(tensor_vec) &&
          dnnl_support_the_dimension_of(tensor_vec) &&
          dnnl_support_the_data_type_of(tensor_vec);
 }
@@ -57,6 +58,14 @@ bool dnnl_support_the_dimension_of(const std::vector<at::Tensor> &tensor_vec) {
 bool dnnl_tensor_has_data(const std::vector<at::Tensor> &tensor_vec) {
   for (auto it = tensor_vec.begin(); it != tensor_vec.end(); ++it)
     if (it->numel() == 0)
+      return false;
+
+  return true;
+}
+
+bool all_is_dpcpp(const std::vector<at::Tensor> &tensor_vec) {
+  for (auto it = tensor_vec.begin(); it != tensor_vec.end(); ++it)
+    if (!it->device().is_dpcpp())
       return false;
 
   return true;

--- a/torch_ipex/csrc/cpu/dbl/DNNLChecker.h
+++ b/torch_ipex/csrc/cpu/dbl/DNNLChecker.h
@@ -62,12 +62,20 @@ bool dnnl_support_the_data_type_of(const std::vector<at::Tensor> &tensor_vec);
 bool dnnl_support_the_dimension_of(const std::vector<at::Tensor> &tensor_vec);
 
 /**
- * Check if the input tensor has data
+ * Check if all input tensors has data
  *
  * @param tensor_vec input tensors
  *
  */
 static inline bool dnnl_tensor_has_data(const std::vector<at::Tensor> &tensor_vec);
+
+/**
+ * Check if all input tensors are dpcpp tensor
+ *
+ * @param tensor_vec input tensors
+ *
+ */
+bool all_is_dpcpp(const std::vector<at::Tensor> &tensor_vec);
 
 }  // namespace chk
 }  // namespace dbl


### PR DESCRIPTION
- force all inputs to be dpcpp tensor
- fix convolution_overrideable cannot be fallbacked to cpu. Fix #60 