### PR TITLE
disable mixed precision in bn fusion & clone

### DIFF
--- a/intel_pytorch_extension_py/ops/jit_script.py
+++ b/intel_pytorch_extension_py/ops/jit_script.py
@@ -1,4 +1,5 @@
 import torch
+import intel_pytorch_extension as ipex
 import _torch_ipex as core
 from torch.jit._recursive import wrap_cpp_module
 
@@ -13,7 +14,12 @@ def script_(obj, optimize=None, _frames_up=0, _rcb=None):
     torch.jit.script = script_
 
     if core.get_jit_opt():
+        # Disable mix precision in model fusion, since mixed precision cannot
+        # bring any benefits for inference, but will lead to loss of accuracy
+        orig_mixed_type = ipex.get_auto_mix_precision()
+        ipex.enable_auto_mix_precision(None)
         jit_m = wrap_cpp_module(torch._C._jit_pass_fold_convbn(jit_m._c))
+        ipex.enable_auto_mix_precision(orig_mixed_type)
 
     return jit_m
 

--- a/torch_ipex/csrc/cpu/DevOPs.cpp
+++ b/torch_ipex/csrc/cpu/DevOPs.cpp
@@ -1351,7 +1351,6 @@ at::Tensor AtenIpexCPUDev::dil_clone(const at::Tensor& self, c10::optional<c10::
   DEBUG("AtenIpexCPUDev::dil_clone\n");
   CHECK_DNNL_OP_PRE_COND(self);
 
-  dbl::comm::reorder_to_bf16_for_mix_prec(self);
   dil::tensor src = dbl::comm::try_gen_dil_tensor(self);
   dil::tensor dst;
   dil::direct_copy::compute(src, dst);


### PR DESCRIPTION
Disable mix precision in model fusion, since mixed precision in fusion cannot bring any benefits for inference, but will lead to a little bit loss of accuracy, noticed by @jiayisunx 