### PR TITLE
fix jit script error on adaptive_avg_pool2d

### DIFF
--- a/intel_pytorch_extension_py/ops/pooling.py
+++ b/intel_pytorch_extension_py/ops/pooling.py
@@ -44,6 +44,6 @@ def max_pool2d(input, kernel_size: Vector, stride: Vector, padding: Vector, dila
         stride = kernel_size
     return torch.ops.torch_ipex.max_pool2d(input, _pair(kernel_size), _pair(stride), _pair(padding), _pair(dilation), ceil_mode)
 
-F.adaptive_avg_pool2d = adaptive_avg_pool2d
+torch.adaptive_avg_pool2d = adaptive_avg_pool2d
 torch.max_pool2d = max_pool2d
 torch.max_pool3d = max_pool3d


### PR DESCRIPTION
hook torch.adaptive_avg_pool2d instead of F.adaptive_avg_pool2d to fix jit script error on adaptive_avg_pool2d 