### PR TITLE
fix torch._C.ScriptFunction' object has no attribute '_c' problem when convert a function to scripted or traced module

### DIFF
--- a/intel_pytorch_extension_py/ops/jit.py
+++ b/intel_pytorch_extension_py/ops/jit.py
@@ -14,7 +14,7 @@ def script_(obj, optimize=None, _frames_up=0, _rcb=None):
     jit_m = orig_script(obj, optimize=optimize, _frames_up=_frames_up+1, _rcb=_rcb)
     torch.jit.script = script_
 
-    if core.get_jit_opt():
+    if core.get_jit_opt() and isinstance(jit_m, torch._C.ScriptModule):
         # Disable mix precision in model fusion, since mixed precision cannot
         # bring any benefits for inference, but will lead to loss of accuracy
         orig_mixed_type = ipex.get_auto_mix_precision()
@@ -24,14 +24,14 @@ def script_(obj, optimize=None, _frames_up=0, _rcb=None):
     return jit_m
 
 def trace_(func, example_inputs, *args, **kwargs):
-    # Disable mix precision. torch.jit.trace will check the traced output 
-    # against what is expected. Since mix precision will lead to 
+    # Disable mix precision. torch.jit.trace will check the traced output
+    # against what is expected. Since mix precision will lead to
     # loss of accuracy, this will raise warning during torch.jit.trace
     orig_mixed_type = ipex.get_auto_mix_precision()
     ipex.enable_auto_mix_precision(None)
     jit_m = orig_trace(func, example_inputs, *args, **kwargs)
 
-    if core.get_jit_opt():        
+    if core.get_jit_opt() and isinstance(jit_m, torch._C.ScriptModule):
         jit_m = wrap_cpp_module(torch._C._jit_pass_fold_convbn(jit_m._c))
     ipex.enable_auto_mix_precision(orig_mixed_type)
     return jit_m


### PR DESCRIPTION
when we convert a function to a scripted or traced module, there always has the following error:
```
  File "/home/xiaobinz/anaconda3/envs/pytorch-test/lib/python3.6/site-packages/torch/jit/__init__.py", line 551, in _check_trace
    _module_class=_module_class,
  File "/home/xiaobinz/anaconda3/envs/pytorch-test/lib/python3.6/site-packages/torch_ipex-0.1-py3.6-linux-x86_64.egg/intel_pytorch_extension/ops/jit.py", line 37, in trace_
    jit_m = wrap_cpp_module(torch._C._jit_pass_fold_convbn(jit_m._c))
AttributeError: 'torch._C.ScriptFunction' object has no attribute '_c'
```
this PR fix it.