### PR TITLE
Update Dockerfile to include pybind11-dev

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -24,6 +24,7 @@ RUN --mount=type=cache,id=apt-dev,target=/var/cache/apt \
     numactl \
     cmake \
     libjpeg-dev \
+    pybind11-dev \
     libpng-dev \
     && rm -rf /var/lib/apt/lists/*
 RUN /usr/sbin/update-ccache-symlinks


### PR DESCRIPTION
As a fix for issue - https://github.com/intel/intel-extension-for-pytorch/issues/155. As suggested by @jingxu10, adding pybind11-dev allows for a successful build of the Docker container.