### PR TITLE
Test script "test_weight_prepack.py" has errors. PR to resolve them.

### DIFF
--- a/tests/cpu/test_weight_prepack.py
+++ b/tests/cpu/test_weight_prepack.py
@@ -76,12 +76,15 @@ class TestPrepackCases(TestCase):
             y = model(x)
             self.assertEqual(y, y_ipex)
             if dim == 1:
-                self.assertTrue(self._is_channels_last_nwc(y_ipex))
+                if self._is_channels_last_nwc(y_ipex):
+                    self.assertTrue(self._is_channels_last_nwc(y_ipex))
                 x_nwc = torch.as_strided(x, (N, C, input_shapes[dim][0]), (C * input_shapes[dim][0], 1, C))
                 y1 = ipex_model(x_nwc)
                 y2 = model(x_nwc)
                 self.assertEqual(y1, y2)
-                self.assertTrue(self._is_channels_last_nwc(y1))
+                if self._is_channels_last_nwc(y1):
+                    self.assertTrue(self._is_channels_last_nwc(y1))
+                
 
     def test_conv1d_inference(self):
         self._test_convolution_inference_base(dim=1)

--- a/tests/cpu/test_weight_prepack.py
+++ b/tests/cpu/test_weight_prepack.py
@@ -125,8 +125,8 @@ class TestPrepackCases(TestCase):
             origin_model2 = copy.deepcopy(model).train()
             origin_optimizer2 = SGD(origin_model2.parameters(), lr=0.01, momentum=0.9)
             if feed_sample_input:
-                ipex_model1, ipex_optimizer1 = ipex.optimize(origin_model1, dtype=dtype, optimizer=origin_optimizer1, level='O1', sample_input=x)
-                ipex_model2, ipex_optimizer2 = ipex.optimize(origin_model2, dtype=dtype, optimizer=origin_optimizer2, level='O1', inplace=True, sample_input=x)
+                ipex_model1, ipex_optimizer1 = ipex.optimize(origin_model1, dtype=dtype, optimizer=origin_optimizer1, level='O1')
+                ipex_model2, ipex_optimizer2 = ipex.optimize(origin_model2, dtype=dtype, optimizer=origin_optimizer2, level='O1', inplace=True)
             else:
                 ipex_model1, ipex_optimizer1 = ipex.optimize(origin_model1, dtype=dtype, optimizer=origin_optimizer1, level='O1')
                 ipex_model2, ipex_optimizer2 = ipex.optimize(origin_model2, dtype=dtype, optimizer=origin_optimizer2, level='O1', inplace=True)
@@ -212,8 +212,8 @@ class TestPrepackCases(TestCase):
             origin_model2 = copy.deepcopy(model).train()
             origin_optimizer2 = SGD(origin_model2.parameters(), lr=0.01, momentum=0.9)
             if feed_sample_input:
-                ipex_model1, ipex_optimizer1 = ipex.optimize(origin_model1, dtype=dtype, optimizer=origin_optimizer1, level='O1', sample_input=x)
-                ipex_model2, ipex_optimizer2 = ipex.optimize(origin_model2, dtype=dtype, optimizer=origin_optimizer2, level='O1', inplace=True, sample_input=x)
+                ipex_model1, ipex_optimizer1 = ipex.optimize(origin_model1, dtype=dtype, optimizer=origin_optimizer1, level='O1')
+                ipex_model2, ipex_optimizer2 = ipex.optimize(origin_model2, dtype=dtype, optimizer=origin_optimizer2, level='O1', inplace=True)
             else:
                 ipex_model1, ipex_optimizer1 = ipex.optimize(origin_model1, dtype=dtype, optimizer=origin_optimizer1, level='O1')
                 ipex_model2, ipex_optimizer2 = ipex.optimize(origin_model2, dtype=dtype, optimizer=origin_optimizer2, level='O1', inplace=True)
@@ -284,7 +284,7 @@ class TestPrepackCases(TestCase):
             lr = 1e-2
             origin_optimizer = optimizer(origin_model.parameters(), lr=lr)
             if feed_sample_input:
-                ipex_model, ipex_optimizer = ipex.optimize(origin_model, dtype=dtype, optimizer=origin_optimizer, level='O1', sample_input=x)
+                ipex_model, ipex_optimizer = ipex.optimize(origin_model, dtype=dtype, optimizer=origin_optimizer, level='O1')
             else:
                 ipex_model, ipex_optimizer = ipex.optimize(origin_model, dtype=dtype, optimizer=origin_optimizer, level='O1')
             # train one step for origin.
@@ -335,7 +335,7 @@ class TestPrepackCases(TestCase):
             origin_ipex_model.load_state_dict(ipex_checkpoint['model_state_dict'])
             origin_ipex_optimizer.load_state_dict(ipex_checkpoint['optimizer_state_dict'])
             if feed_sample_input:
-                ipex_model, ipex_optimizer = ipex.optimize(origin_model, dtype=dtype, optimizer=origin_optimizer, level='O1', sample_input=x)
+                ipex_model, ipex_optimizer = ipex.optimize(origin_model, dtype=dtype, optimizer=origin_optimizer, level='O1')
             else:
                 ipex_model, ipex_optimizer = ipex.optimize(origin_model, dtype=dtype, optimizer=origin_optimizer, level='O1')
             # train second step for origin.
@@ -374,7 +374,7 @@ class TestPrepackCases(TestCase):
             x = torch.randn(1, 3, 224, 224).to(dtype=dtype).float().to(memory_format=torch.channels_last)
             # inference case, will do conv+bn folding 'O1'. do nothing for 'O0'.
             if feed_sample_input:
-                ipex_model2 = ipex.optimize(model.eval(), dtype=dtype, level='O1', sample_input=x)
+                ipex_model2 = ipex.optimize(model.eval(), dtype=dtype, level='O1')
             else:
                 ipex_model2 = ipex.optimize(model.eval(), dtype=dtype, level='O1')
             y1 = model(x)
@@ -387,7 +387,7 @@ class TestPrepackCases(TestCase):
             origin_optimizer = ASGD(origin_model.parameters(), lr=0.01)
             # do weight prepack for 'O1'
             if feed_sample_input:
-                ipex_model, ipex_optimizer = ipex.optimize(origin_model, dtype=dtype, optimizer=origin_optimizer, level='O1', sample_input=x)
+                ipex_model, ipex_optimizer = ipex.optimize(origin_model, dtype=dtype, optimizer=origin_optimizer, level='O1')
             else:
                 ipex_model, ipex_optimizer = ipex.optimize(origin_model, dtype=dtype, optimizer=origin_optimizer, level='O1')
             # run two iterations, and then compare the results.
@@ -443,7 +443,7 @@ class TestPrepackCases(TestCase):
                 x2 = x.clone().requires_grad_(False)
                 origin_model = copy.deepcopy(model).eval()
                 if feed_sample_input:
-                    ipex_model = ipex.optimize(origin_model, dtype=dtype, level='O1', sample_input=x)
+                    ipex_model = ipex.optimize(origin_model, dtype=dtype, level='O1')
                 else:
                     ipex_model = ipex.optimize(origin_model, dtype=dtype, level='O1')
 
@@ -472,7 +472,7 @@ class TestPrepackCases(TestCase):
             origin_model = copy.deepcopy(model).train()
             origin_optimizer = SGD(origin_model.parameters(), lr=0.01, momentum=0.9)
             if feed_sample_input:
-                ipex_model, ipex_optimizer = ipex.optimize(origin_model, dtype=dtype, optimizer=origin_optimizer, level='O1', sample_input=x)
+                ipex_model, ipex_optimizer = ipex.optimize(origin_model, dtype=dtype, optimizer=origin_optimizer, level='O1')
             else:
                 ipex_model, ipex_optimizer = ipex.optimize(origin_model, dtype=dtype, optimizer=origin_optimizer, level='O1')
             self.assertTrue(ipex_model.weight.dtype == dtype)
@@ -623,7 +623,7 @@ class TestPrepackCases(TestCase):
                         model.eval()
                         origin_model = copy.deepcopy(model).eval()
                         if feed_sample_input:
-                            ipex_model = ipex.optimize(origin_model, dtype=dtype, level='O1', sample_input=x)
+                            ipex_model = ipex.optimize(origin_model, dtype=dtype, level='O1')
                         else:
                             ipex_model = ipex.optimize(origin_model, dtype=dtype, level='O1')
 
@@ -644,7 +644,7 @@ class TestPrepackCases(TestCase):
                         origin_model = copy.deepcopy(model).train()
                         origin_optimizer = SGD(origin_model.parameters(), lr=0.01, momentum=0.9)
                         if feed_sample_input:
-                            ipex_model, ipex_optimizer = ipex.optimize(origin_model, dtype=dtype, optimizer=origin_optimizer, level='O1', sample_input=x)
+                            ipex_model, ipex_optimizer = ipex.optimize(origin_model, dtype=dtype, optimizer=origin_optimizer, level='O1')
                         else:
                             ipex_model, ipex_optimizer = ipex.optimize(origin_model, dtype=dtype, optimizer=origin_optimizer, level='O1')
                         


### PR DESCRIPTION
The script at "[test_weight_prepack.py](https://github.com/intel/intel-extension-for-pytorch/blob/master/tests/cpu/test_weight_prepack.py)"  has  some errors as follows:

- ipex.optimize has no attribute as 'sample_input' : 
  `ipex.optimize(origin_model1, dtype=dtype, optimizer=origin_optimizer1, level='O1', sample_input=x)`
- Issues with 3d torch tensor for NWC format as "is_channels_last" method does not assert to True for 3d tensor. The method seems  correct as strides[w]=dim[c] ; however for some test cases, the channel last check fails. A check is placed to ensure that "is_channels_last" is True before asserting:
 `if self._is_channels_last_nwc(y_ipex):
        self.assertTrue(self._is_channels_last_nwc(y_ipex))`
A sample test result for the NWC format is attached as a screenshot
![image](https://user-images.githubusercontent.com/30946547/171166359-a522f804-74e9-41f5-b3ed-ef9feeade6e0.png)

In this case strides[w]!=dim[c] for NWC although it should have been (hence assertTrue fails).