### PR TITLE
Fix typo in _tensor_method.py

### DIFF
--- a/intel_extension_for_pytorch/nn/functional/_tensor_method.py
+++ b/intel_extension_for_pytorch/nn/functional/_tensor_method.py
@@ -3,7 +3,7 @@ import warnings
 
 def _numpy(x):
     if x.dtype==torch.bfloat16:
-        warnings.warn("calling in ipex numpy which is not share mermory with torch tensor for bfloat16 input.")
+        warnings.warn("calling in ipex numpy which is not share memory with torch tensor for bfloat16 input.")
         return torch._C._TensorBase.numpy(x.float())
     else:
         return torch._C._TensorBase.numpy(x)


### PR DESCRIPTION
Found a small typo in _tensor_method.py where memory was mis-spelled as mermory.