### PR TITLE
Fix xpu sample in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ data = torch.rand(1, 3, 224, 224)
 
 import intel_extension_for_pytorch as ipex
 model.to('xpu')
-data.to('xpu')
+data = data.to('xpu')
 model = ipex.optimize(model)
 
 with torch.no_grad():


### PR DESCRIPTION
Currently the sample produces the following error:
```
/home/workflow-arc/pyenvs/ipt39/lib/python3.9/site-packages/intel_extension_for_pytorch/frontend.py:277: UserWarning: pending the optimization for LSTM
  warnings.warn("pending the optimization for LSTM")
Traceback (most recent call last):
  File "/home/workflow-arc/code/intel-extension-for-pytorch/../ipt_samples/gpu_inf.py", line 15, in <module>
    model(data)
  File "/home/workflow-arc/pyenvs/ipt39/lib/python3.9/site-packages/torch/fx/graph_module.py", line 616, in wrapped_call
    raise e.with_traceback(None)
RuntimeError: Input type (torch.FloatTensor) and weight type (XPUFloatType) should be the same or input should be a MKLDNN tensor and weight is a dense tensor
```
Method torch.Tensor.to() returns a copy of the tensor located on the specified device, while the original tensor is not moved: see https://pytorch.org/docs/stable/generated/torch.Tensor.to.html