### PR TITLE
fix wget address of compile_bundle.sh

### DIFF
--- a/docs/tutorials/installation.md
+++ b/docs/tutorials/installation.md
@@ -86,7 +86,7 @@ python -m pip install <package_name>==<version_name> -f https://developer.intel.
 To ensure a smooth compilation, a script is provided in the Github repo. If you would like to compile the binaries from source, it is highly recommended to utilize this script.
 
 ```bash
-$ wget https://github.com/intel/intel-extension-for-pytorch/blob/master/scripts/compile_bundle.sh
+$ wget https://raw.githubusercontent.com/intel/intel-extension-for-pytorch/master/scripts/compile_bundle.sh
 $ bash compile_bundle.sh
 ```
 


### PR DESCRIPTION
Current address of compile_bundle.sh will get an html file instead of an sh file.
Use raw.githubusercontent.com resources instead.