### PR TITLE
enhancement: print stack when  ipex.optimize fail

### DIFF
--- a/intel_extension_for_pytorch/frontend.py
+++ b/intel_extension_for_pytorch/frontend.py
@@ -30,6 +30,7 @@ import logging
 import threading
 from typing import Callable, Dict, Optional, Union
 import builtins
+import traceback
 
 def _copy_model_and_optimizer(model, optimizer):
     new_model = copy.deepcopy(model)
@@ -474,8 +475,8 @@ def optimize(
         if opt_properties.conv_bn_folding:
             try:
                 optimized_model = optimization.fuse(optimized_model, inplace=inplace)
-            except:  # noqa E722
-                warnings.warn("Conv BatchNorm folding failed during the optimize process.")
+            except Exception as e:
+                traceback.print_exc()
         if opt_properties.linear_bn_folding:
             try:
                 optimized_model = linear_bn_fuse(optimized_model, inplace=inplace)


### PR DESCRIPTION
Currently, when call ipex.optimize(m) will failure due to limitation of torch.fx, but the warning message is
"Conv BatchNorm folding failed during the optimize process.", looks like unreasonable.
traceback.print_exc() will help the user to locate the fail point.