### PR TITLE
Regex should be using a raw string

### DIFF
--- a/intel_extension_for_pytorch/__init__.py
+++ b/intel_extension_for_pytorch/__init__.py
@@ -1,3 +1,5 @@
+import re
+
 import torch
 try:
     import torchvision
@@ -11,11 +13,10 @@ _cpu_isa.check_minimal_isa_support()
 
 torch_version = ''
 ipex_version = ''
-import re
-matches = re.match('(\d+\.\d+).*', torch.__version__)
+matches = re.match(r'(\d+\.\d+).*', torch.__version__)
 if matches and len(matches.groups()) == 1:
   torch_version = matches.group(1)
-matches = re.match('(\d+\.\d+).*', __version__)
+matches = re.match(r'(\d+\.\d+).*', __version__)
 if matches and len(matches.groups()) == 1:
   ipex_version = matches.group(1)
 if torch_version == '' or ipex_version == '' or torch_version != ipex_version:


### PR DESCRIPTION
Current code gives the following warning:

```
../usr/local/lib/python3.8/site-packages/intel_extension_for_pytorch/__init__.py:15
  /usr/local/lib/python3.8/site-packages/intel_extension_for_pytorch/__init__.py:15: DeprecationWarning: invalid escape sequence \d
    matches = re.match('(\d+\.\d+).*', torch.__version__)

../usr/local/lib/python3.8/site-packages/intel_extension_for_pytorch/__init__.py:18
  /usr/local/lib/python3.8/site-packages/intel_extension_for_pytorch/__init__.py:18: DeprecationWarning: invalid escape sequence \d
    matches = re.match('(\d+\.\d+).*', __version__)
```

The resolution is either to use double backslashes (as in `"\\d"` to match a single digit) or to use raw strings (preferred to reduce visual load).