### PR TITLE
Fix license metadata

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -882,4 +882,8 @@ setup(
     ext_modules=ext_modules,
     cmdclass=cmdclass,
     entry_points=entry_points,
+    license='https://www.apache.org/licenses/LICENSE-2.0',
+    classifiers=[
+        'License :: OSI Approved :: Apache Software License',
+    ],
     )


### PR DESCRIPTION
License doesn't show in PyPI and isn't caught by license scanners. 

See left metadata panel on projects like https://pypi.org/project/apache-flink/ that doesn't show on https://pypi.org/project/intel-extension-for-pytorch/.

Example setup.py in that project is here: https://github.com/apache/flink/blob/742685b76c7f001a08799a539cad2bb683d5d29d/flink-python/setup.py#L327

The setup call in setup.py needs the below. Thanks!

        license='https://www.apache.org/licenses/LICENSE-2.0',
        classifiers=[
            'License :: OSI Approved :: Apache Software License',
        ],