### PR TITLE
Enable inductor for xpu backend

### DIFF
--- a/intel_extension_for_pytorch/_inductor/__init__.py
+++ b/intel_extension_for_pytorch/_inductor/__init__.py
@@ -1,0 +1,9 @@
+from torch._inductor.codegen.common import register_backend_for_device
+
+from . import xpu
+
+from .xpu.codegen.triton import XPUTritonScheduling
+from .xpu.codegen.wrapper import XPUTritonWrapperCodeGen
+
+# Register triton XPU backend in PyTorch _inductor.
+register_backend_for_device("xpu", XPUTritonScheduling, XPUTritonWrapperCodeGen)

--- a/intel_extension_for_pytorch/_inductor/xpu/__init__.py
+++ b/intel_extension_for_pytorch/_inductor/xpu/__init__.py
@@ -1,0 +1,6 @@
+from .overrides import override_decode_device
+from .utils import has_triton
+
+
+if has_triton():
+    override_decode_device()

--- a/intel_extension_for_pytorch/_inductor/xpu/__init__.py
+++ b/intel_extension_for_pytorch/_inductor/xpu/__init__.py
@@ -3,4 +3,6 @@ from .utils import has_triton
 
 
 if has_triton():
+    # Here we have to override decode_device since it is hardcode with CUDA in
+    # PyTorch inductor.
     override_decode_device()

--- a/intel_extension_for_pytorch/_inductor/xpu/codecache.py
+++ b/intel_extension_for_pytorch/_inductor/xpu/codecache.py
@@ -1,0 +1,105 @@
+import functools
+import multiprocessing
+import os
+import signal
+import sys
+from concurrent.futures import ProcessPoolExecutor
+from threading import Thread
+from time import sleep
+
+import torch
+
+from torch._inductor import config
+from torch._inductor.codecache import (
+    _compile_start,
+    _compile_end,
+    _worker_compile,
+    _load_kernel,
+    TritonFuture,
+    AsyncCompile,
+)
+
+
+class XPUAsyncCompile(AsyncCompile):
+    def __init__(self):
+        super().__init__()
+
+    @staticmethod
+    @functools.lru_cache(1)
+    def process_pool():
+        assert config.compile_threads > 1
+        orig_ppid = os.getpid()
+
+        # if this process dies abnormally (e.g. segfault)
+        # it will not shut down the workers. Instead
+        # the workers will have their parent reassigned to the
+        # init process. This launches a separate thread to
+        # watch for the worker getting reassigned,
+        # and cleans it up in this case.
+        def init():
+            def run():
+                while True:
+                    sleep(1)
+                    if orig_ppid != os.getppid():
+                        os.kill(os.getpid(), signal.SIGKILL)
+
+            global _watchdog_thread
+            _watchdog_thread = Thread(target=run, daemon=True)
+            _watchdog_thread.start()
+
+        # we rely on 'fork' because we cannot control whether users
+        # have an `if __name__ == '__main__'` in their main process.
+        fork_context = multiprocessing.get_context("fork")
+        pool = ProcessPoolExecutor(
+            config.compile_threads, mp_context=fork_context, initializer=init
+        )
+        # when this pool is created in a subprocess object, the normal exit handler
+        # doesn't run, and we need to register our own handler.
+        # exitpriority has to be high, because another one of the finalizers will
+        # kill the worker thread that sends the shutdown message to the workers...
+        multiprocessing.util.Finalize(None, pool.shutdown, exitpriority=sys.maxsize)
+        return pool
+
+    @classmethod
+    def warm_pool(cls):
+        if config.compile_threads <= 1:
+            return
+        _compile_start()
+        pool = cls.process_pool()
+
+        # We have to fork processes for compiler workers, but the more memory and other resources that are loaded, the
+        # slower the os.fork time is, quite drastically. It also holds the GIL so we can't put it on another thread.
+
+        # Examples:
+        # A simple x + x + x script: 10ms seconds in the middle of the program, 2ms at startup
+        # tf_efficientnet_b0 benchmark: 50ms! in the middle of the program , 3ms at startup
+
+        # So we want to start the workers early when it is still cheap, and also to allow the workers to get
+        # ready before we have work for them.
+
+        # ProcessPoolExecutor also does not launch the workers until it finds a point when all the workers are idle.
+        # But if we waited until then fork time will be long and we will be waiting for the processes to initialize.
+
+        # We force them to start here with some YOLOing of the internal methods.
+        if hasattr(pool, "_start_queue_management_thread"):
+            pool._start_queue_management_thread()
+        else:
+            for _ in range(config.compile_threads):
+                pool._adjust_process_count()
+            pool._start_executor_manager_thread()
+        _compile_end()
+
+    def triton(self, source_code):
+        _compile_start()
+
+        if config.compile_threads > 1:
+            device = torch.xpu.current_device()
+            cc = None
+            future = self.process_pool().submit(
+                _worker_compile, source_code, cc, device
+            )
+            return TritonFuture(source_code, future)
+        else:
+            return _load_kernel(source_code)
+
+XPUAsyncCompile.warm_pool()

--- a/intel_extension_for_pytorch/_inductor/xpu/codegen/triton.py
+++ b/intel_extension_for_pytorch/_inductor/xpu/codegen/triton.py
@@ -1,0 +1,404 @@
+import contextlib
+
+import sympy
+
+import torch  # noqa
+
+from torch._dynamo import config as dynamo_config
+from torch._inductor.ir import ReductionHint
+from torch._inductor.optimize_indexing import indexing_dtype_strength_reduction
+
+from torch._inductor.virtualized import V
+
+from torch._inductor.codegen.common import (
+    IndentedBuffer,
+    PythonPrinter,
+    SizeArg,
+)
+from torch._inductor.codegen.triton import (
+    signature_of,
+    config_of,
+    TritonPrinter,
+    TritonOverrides,
+    TritonKernel,
+    TritonScheduling,
+    DisableReduction,
+    EnableReduction,
+)
+
+
+class XPUTritonPrinter(TritonPrinter):
+    def _print_floor(self, expr):
+        assert len(expr.args) == 1
+        return f"tl.math.floor({self.paren(self._print(expr.args[0]))})"
+
+
+texpr = XPUTritonPrinter().doprint
+pexpr = PythonPrinter().doprint
+
+
+class XPUTritonOverrides(TritonOverrides):
+    """Map element-wise ops to XPU Triton backend"""
+
+    @staticmethod
+    def libdevice_abs(x):
+        return f"tl.math.abs({x})"
+
+    @staticmethod
+    def libdevice_exp(x):
+        return f"tl.math.exp({x})"
+
+    @staticmethod
+    def exp2(x):
+        return f"tl.math.exp2({x})"
+
+    @staticmethod
+    def expm1(x):
+        return f"tl.math.expm1({x})"
+
+    @staticmethod
+    def libdevice_sqrt(x):
+        return f"tl.math.sqrt({x})"
+
+    @staticmethod
+    def libdevice_cos(x):
+        return f"tl.math.cos({x})"
+
+    @staticmethod
+    def libdevice_sin(x):
+        return f"tl.math.sin({x})"
+
+    @staticmethod
+    def lgamma(x):
+        return f"tl.math.lgamma({x})"
+
+    @staticmethod
+    def erf(x):
+        return f"tl.math.erf({x})"
+
+    @staticmethod
+    def cosh(x):
+        return f"tl.math.cosh({x})"
+
+    @staticmethod
+    def sinh(x):
+        return f"tl.math.sinh({x})"
+
+    @staticmethod
+    def acos(x):
+        return f"tl.math.acos({x})"
+
+    @staticmethod
+    def acosh(x):
+        return f"tl.math.acosh({x})"
+
+    @staticmethod
+    def asin(x):
+        return f"tl.math.asin({x})"
+
+    @staticmethod
+    def asinh(x):
+        return f"tl.math.asinh({x})"
+
+    @staticmethod
+    def atan2(x, y):
+        return f"tl.math.atan2({x}, {y})"
+
+    @staticmethod
+    def atan(x):
+        return f"tl.math.atan({x})"
+
+    @staticmethod
+    def atanh(x):
+        return f"tl.math.atanh({x})"
+
+    @staticmethod
+    def copysign(x, y):
+        return f"tl.math.copysign({x}, {y})"
+
+    @staticmethod
+    def erfc(x):
+        return f"tl.math.erfc({x})"
+
+    @staticmethod
+    def hypot(x, y):
+        return f"tl.math.hypot({x}, {y})"
+
+    @staticmethod
+    def log10(x):
+        return f"tl.math.log10({x})"
+
+    @staticmethod
+    def nextafter(x, y):
+        return f"tl.math.nextafter({x}, {y})"
+
+    @staticmethod
+    def rsqrt(x):
+        return f"tl.math.rsqrt({x})"
+
+    @staticmethod
+    def log1p(x):
+        return f"tl.math.log1p({x})"
+
+    @staticmethod
+    def tan(x):
+        return f"tl.math.tan({x})"
+
+    @staticmethod
+    def tanh(x):
+        return f"tl.math.tanh({x})"
+
+    @staticmethod
+    def libdevice_sigmoid(x):
+        return f"1/(1 + tl.math.exp(-({x})))"
+
+    @staticmethod
+    def signbit(x):
+        # XX: This is wrong for the value -0.0 in floating point
+        return f"tl.math.signbit({x}) if ({x}).dtype is tl.float32 else {x} < 0"
+
+    @staticmethod
+    def fmod(a, b):
+        return f"tl.math.fmod({a}, {b})"
+
+    @staticmethod
+    def pow(a, b):
+        return f"tl.math.pow({a}, {b})"
+
+    @staticmethod
+    def libdevice_log(x):
+        return f"tl.math.log({x})"
+
+    @staticmethod
+    def isinf(x):
+        return f"tl.math.isinf({x})"
+
+    @staticmethod
+    def isnan(x):
+        return f"tl.math.isnan({x})"
+
+    @staticmethod
+    def round(x):
+        return f"tl.math.nearbyint({x})"
+
+    @staticmethod
+    def floor(x):
+        return f"tl.math.floor({x})"
+
+    @staticmethod
+    def trunc(x):
+        return f"tl.math.trunc({x})"
+
+    @staticmethod
+    def ceil(x):
+        return f"tl.math.ceil({x})"
+
+
+class XPUTritonKernel(TritonKernel):
+    overrides = XPUTritonOverrides
+    sexpr = pexpr
+
+    def __init__(
+        self,
+        *groups,
+        mutations=None,
+        pid_cache=None,
+        reduction_hint=ReductionHint.DEFAULT,
+    ):
+        super().__init__(*groups, mutations=mutations, pid_cache=pid_cache, reduction_hint=reduction_hint)
+
+    def codegen_kernel(self, name=None):
+        from triton import next_power_of_2
+
+        code = IndentedBuffer()
+        size_hints = [
+            next_power_of_2(V.graph.sizevars.size_hint(numel)) for numel in self.numels
+        ]
+        if self.persistent_reduction:
+            assert self.inside_reduction
+            heuristics = "persistent_reduction"
+        elif self.inside_reduction:
+            heuristics = "reduction"
+        else:
+            size_hints.pop()
+            heuristics = "pointwise"
+
+        if name is None:
+            code.splice(
+                f"""
+                    import triton
+                    import triton.language as tl
+                    from torch._inductor.ir import ReductionHint
+                    from torch._inductor.ir import TileHint
+                    from intel_extension_for_pytorch._inductor.xpu.triton_ops.autotune import {heuristics}
+                    from torch._inductor.utils import instance_descriptor
+                """
+            )
+
+        argdefs, _, signature = self.args.python_argdefs()
+        # maps actual expression to SizeArg if its in sizevars replacements
+        for i, arg in enumerate(signature):
+            if (
+                isinstance(arg, SizeArg)
+                and arg.expr in V.graph.sizevars.inv_precomputed_replacements
+            ):
+                signature[i] = SizeArg(
+                    arg.name, V.graph.sizevars.inv_precomputed_replacements[arg.expr]
+                )
+
+        mutated_args = set()
+        for mutation in self.mutations:
+            if mutation in self.args.input_buffers:
+                mutated_args.add(self.args.input_buffers[mutation])
+            if mutation in self.args.inplace_buffers:
+                mutated_args.add(self.args.inplace_buffers[mutation].inner_name)
+            if mutation in self.args.output_buffers:
+                mutated_args.add(self.args.output_buffers[mutation])
+        mutated_args = sorted(mutated_args)
+
+        triton_meta = {
+            "signature": dict(enumerate(map(signature_of, signature))),
+            "device": V.graph.scheduler.current_device.index,
+            "device_type": V.graph.scheduler.current_device.type,
+            "constants": {},
+            "mutated_arg_names": mutated_args,
+        }
+
+        for tree in self.range_trees:
+            if tree.prefix != "r" or self.inside_reduction:
+                sizearg = SizeArg(f"{tree.prefix}numel", tree.numel)
+                signature.append(sizearg)
+                triton_meta["signature"][len(argdefs)] = signature_of(sizearg)
+                argdefs.append(f"{tree.prefix}numel")
+                # constexpr version causes issues, see
+                # https://github.com/pytorch/torchdynamo/pull/1362
+                # triton_meta["constants"][len(argdefs)] = V.graph.sizevars.size_hint(
+                #     tree.numel
+                # )
+                # argdefs.append(f"{tree.prefix}numel: tl.constexpr")
+        triton_meta["configs"] = [config_of(signature)]
+
+        for tree in self.range_trees:
+            if tree.prefix != "r" or self.inside_reduction:
+                argdefs.append(f"{tree.prefix.upper()}BLOCK : tl.constexpr")
+
+        if self.inside_reduction:
+            reduction_hint = self.reduction_hint
+            heuristics_line = f"""
+                @{heuristics}(
+                    size_hints={size_hints!r},
+                    reduction_hint={reduction_hint},
+                    filename=__file__,
+                    meta={triton_meta!r}
+                )
+                @triton.jit
+            """
+        else:
+            tile_hint = ""
+            if len(size_hints) == 2:
+                if len(signature) == 4:  # input, output and 2 args
+                    tile_hint = "tile_hint=TileHint.SQUARE,"
+                else:
+                    tile_hint = "tile_hint=TileHint.DEFAULT,"
+            heuristics_line = f"""
+                @{heuristics}(size_hints={size_hints!r}, {tile_hint}filename=__file__, meta={triton_meta!r})
+                @triton.jit
+            """
+        code.splice(heuristics_line)
+        code.writeline(f"def {name or 'KERNEL_NAME'}({', '.join(argdefs)}):")
+        self.codegen_body()
+        with code.indent():
+            if not dynamo_config.dynamic_shapes:
+                self.codegen_static_numels(code)
+            for old, new in self.args.aliases():
+                code.writeline(f"{old} = {new}")
+            code.splice(self.body)
+
+        if name is not None:
+            return code.getvalue()
+
+        wrapper = IndentedBuffer()
+        wrapper.writeline("async_compile.triton('''")
+        wrapper.splice(code.getvalue(), strip=True)
+        wrapper.writeline("''')")
+        return wrapper.getvalue()
+
+    def call_kernel(self, code, name: str):
+        _, call_args, _ = self.args.python_argdefs()
+        # dynamo wraps unspec variable as 0d CPU tensor, need convert to scalar
+        for i in range(len(call_args)):
+            if V.graph.is_unspec_arg(call_args[i]):
+                call_args[i] = call_args[i] + ".item()"
+        grid = []
+        # TODO(jansel): if there are constants, we shouldn't bother passing them as args
+        for tree in self.range_trees:
+            if isinstance(tree.numel, (sympy.Integer, sympy.Symbol)):
+                expr = pexpr(tree.numel)
+            else:
+                expr = f"{name}_{tree.prefix}numel"
+                code.writeline(f"{expr} = {pexpr(tree.numel)}")
+            if tree.prefix != "r" or self.inside_reduction:
+                call_args.append(expr)
+            if tree.prefix != "r":
+                grid.append(expr)
+        call_args = ", ".join(call_args)
+        stream_name = code.write_get_xpu_stream(V.graph.scheduler.current_device.index)
+        code.writeline(
+            f"{name}.run({call_args}, grid=grid({', '.join(grid)}), stream={stream_name})"
+        )
+
+
+class XPUTritonScheduling(TritonScheduling):
+    def __init__(self, scheduler):
+        super().__init__(scheduler)
+
+    def codegen_node_schedule(self, node_schedule, numel, reduction_numel):
+        tiled_groups = self.select_tiling(node_schedule, numel, reduction_numel)
+        reductions = list(
+            filter(
+                lambda n: n not in (EnableReduction, DisableReduction)
+                and n.is_reduction(),
+                node_schedule,
+            )
+        )
+        if len(reductions) > 0:
+            hints = [self.reduction_hint(n) for n in reductions]
+            if hints.count(hints[0]) == len(hints):
+                reduction_hint_val = hints[0]
+            else:
+                reduction_hint_val = ReductionHint.DEFAULT
+        else:
+            reduction_hint_val = ReductionHint.DEFAULT
+
+        mutations = set()
+        for node in node_schedule:
+            if hasattr(node, "get_mutations"):
+                mutations.update(node.get_mutations())
+
+        with XPUTritonKernel(
+            *tiled_groups, reduction_hint=reduction_hint_val, mutations=mutations
+        ) as kernel:
+            stack = contextlib.ExitStack()
+            for node in node_schedule:
+                if node not in (EnableReduction, DisableReduction):
+                    node.mark_run()
+            for node in node_schedule:
+                if node is DisableReduction:
+                    stack.enter_context(kernel.disable_reduction())
+                elif node is EnableReduction:
+                    stack.close()
+                else:
+                    # TODO - mostly works but needs a couple fixes
+                    if not dynamo_config.dynamic_shapes:
+                        # TODO - use split ranges ?
+                        indexing_dtype_strength_reduction(node._body)
+                    index_vars = kernel.split_and_set_ranges(node.get_ranges())
+                    node.codegen(index_vars)
+
+        src_code = kernel.codegen_kernel()
+        kernel_name = self.define_kernel(src_code, node_schedule)
+        kernel.call_kernel(V.graph.wrapper_code, kernel_name)
+        self.scheduler.free_buffers()
+
+    def codegen_sync(self):
+        V.graph.wrapper_code.writeline("torch.xpu.synchronize()")

--- a/intel_extension_for_pytorch/_inductor/xpu/codegen/wrapper.py
+++ b/intel_extension_for_pytorch/_inductor/xpu/codegen/wrapper.py
@@ -1,0 +1,216 @@
+import contextlib
+import dataclasses
+import functools
+import hashlib
+
+from torch._dynamo.utils import dynamo_timed
+
+from torch._inductor import config
+from torch._inductor.virtualized import V
+from torch._inductor.codegen.common import IndentedBuffer, PythonPrinter
+from torch._inductor.codegen.wrapper import (
+    MemoryPlanningState,
+    MemoryPlanningLine,
+    WrapperCodeGen,
+)
+from .. import codecache
+from ..utils import has_triton
+
+pexpr = PythonPrinter().doprint
+
+
+@dataclasses.dataclass
+class EnterXPUDeviceContextManagerLine:
+    device_idx: int
+
+    def codegen(self, code: IndentedBuffer):
+        # Note _DeviceGuard has less overhead than device, but only accepts
+        # integers
+        code.writeline(f"with torch.xpu._DeviceGuard({self.device_idx}):")
+
+
+class ExitXPUDeviceContextManagerLine:
+    pass
+
+
+class XPUTritonWrapperCodeGen(WrapperCodeGen):
+    """
+    The outer wrapper that calls the kernels.
+    """
+
+    def __init__(self):
+        super().__init__()
+        self.header = IndentedBuffer()
+        self.header.splice(
+            f"""
+                from ctypes import c_void_p, c_long
+                import torch
+                import math
+                import random
+                from torch import empty_strided, as_strided, device
+                from {codecache.__name__} import XPUAsyncCompile
+                from torch._inductor.select_algorithm import extern_kernels
+
+                aten = torch.ops.aten
+                assert_size_stride = torch._C._dynamo.guards.assert_size_stride
+                async_compile = XPUAsyncCompile()
+
+            """
+        )
+
+        if has_triton():
+            self.header.splice(
+                """
+                import triton
+                import triton.language as tl
+                from torch._inductor.triton_ops.autotune import grid
+                from intel_extension_for_pytorch._C import _getCurrentRawStream as get_xpu_stream
+                """
+            )
+
+        for name, value in V.graph.constants.items():
+            # include a hash so our code cache gives different constants different files
+            hashed = hashlib.sha256(repr(value).encode("utf-8")).hexdigest()
+            self.header.writeline(f"{name} = None  # {hashed}")
+
+        self.write_get_xpu_stream = functools.lru_cache(None)(
+            self.write_get_xpu_stream
+        )
+
+    def write_prefix(self):
+        self.prefix.splice(
+            """
+
+            async_compile.wait(globals())
+            del async_compile
+
+            def call(args):
+            """
+        )
+        with self.prefix.indent():
+            if config.triton.debug_sync_graph:
+                self.prefix.writeline("torch.xpu.synchronize()")
+            inp_len = len(V.graph.graph_inputs.keys())
+            if inp_len != 0:
+                lhs = f"{', '.join(V.graph.graph_inputs.keys())}{'' if inp_len != 1 else ','}"
+                self.prefix.writeline(f"{lhs} = args")
+                self.prefix.writeline("args.clear()")
+            for name in V.graph.randomness_seeds:
+                self.prefix.writeline(
+                    f"torch.randint(2**31, size=(), dtype=torch.int64, out={name})"
+                )
+            V.graph.sizevars.codegen(self.prefix, V.graph.graph_inputs)
+
+    def write_get_xpu_stream(self, index):
+        name = f"stream{index}"
+        self.writeline(f"{name} = get_xpu_stream({index})")
+        return name
+
+    def codegen_device_guard_enter(self, device_idx):
+        self.lines.append(EnterXPUDeviceContextManagerLine(device_idx))
+
+    def codegen_device_guard_exit(self):
+        self.lines.append(ExitXPUDeviceContextManagerLine())
+
+    @dynamo_timed
+    def generate(self):
+        result = IndentedBuffer()
+        result.splice(self.header)
+
+        out_names = V.graph.get_output_names()
+        with contextlib.ExitStack() as stack:
+            stack.enter_context(self.wrapper_call.indent())
+            if config.profiler_mark_wrapper_call:
+                self.wrapper_call.writeline(
+                    "from torch.profiler import record_function"
+                )
+                self.wrapper_call.writeline(
+                    "with record_function('inductor_wrapper_call'):"
+                )
+                stack.enter_context(self.wrapper_call.indent())
+            while (
+                self.lines
+                and isinstance(self.lines[-1], MemoryPlanningLine)
+                and self.lines[-1].node.name not in out_names
+            ):
+                # these lines will be pointless
+                self.lines.pop()
+
+            # codegen allocations in two passes
+            planning_state = MemoryPlanningState()
+            for i in range(len(self.lines)):
+                if isinstance(self.lines[i], MemoryPlanningLine):
+                    self.lines[i] = self.lines[i].plan(planning_state)
+
+            device_cm_stack = contextlib.ExitStack()
+            for line in self.lines:
+                if isinstance(line, MemoryPlanningLine):
+                    line.codegen(self.wrapper_call)
+                elif isinstance(line, EnterXPUDeviceContextManagerLine):
+                    line.codegen(self.wrapper_call)
+                    device_cm_stack.enter_context(self.wrapper_call.indent())
+                    self.wrapper_call.writeline(
+                        f"torch.xpu.set_device({line.device_idx}) # no-op to ensure context"
+                    )
+                elif isinstance(line, ExitXPUDeviceContextManagerLine):
+                    device_cm_stack.close()
+                else:
+                    self.wrapper_call.writeline(line)
+
+            output_refs = self.get_output_refs()
+            if config.triton.debug_sync_graph:
+                self.wrapper_call.writeline("torch.xpu.synchronize()")
+            self.generate_return(output_refs)
+
+        self.append_precomputed_sizes_to_prefix()
+        result.splice(self.prefix)
+
+        with result.indent():
+            result.splice(self.wrapper_call)
+
+        self.generate_end(result)
+
+        self.add_benchmark_harness(result)
+
+        return result.getvalue()
+
+    def add_benchmark_harness(self, output):
+        """
+        Append a benchmark harness to generated code for debugging
+        """
+        if not config.benchmark_harness:
+            return
+
+        def add_fake_input(name, shape, stride, device, dtype):
+            output.writeline(
+                f"{name} = rand_strided("
+                f"{V.graph.sizevars.codegen_benchmark_shape_tuple(shape)}, "
+                f"{V.graph.sizevars.codegen_benchmark_shape_tuple(stride)}, "
+                f"device='{device}', dtype={dtype})"
+            )
+
+        output.writelines(["", "", 'if __name__ == "__main__":'])
+        with output.indent():
+            output.splice(
+                """
+                from torch._dynamo.testing import rand_strided
+                from intel_extension_for_pytorch._inductor.xpu.utils import print_performance
+                """,
+                strip=True,
+            )
+
+            for name, value in V.graph.constants.items():
+                add_fake_input(
+                    name, value.size(), value.stride(), value.device, value.dtype
+                )
+
+            for name, value in V.graph.graph_inputs.items():
+                shape = [V.graph.sizevars.size_hint(x) for x in value.get_size()]
+                stride = [V.graph.sizevars.size_hint(x) for x in value.get_stride()]
+                add_fake_input(
+                    name, shape, stride, value.get_device(), value.get_dtype()
+                )
+
+            output.writeline(
+                f"print_performance(lambda: call([{', '.join(V.graph.graph_inputs.keys())}]))"
+            )

--- a/intel_extension_for_pytorch/_inductor/xpu/lowering.py
+++ b/intel_extension_for_pytorch/_inductor/xpu/lowering.py
@@ -1,0 +1,15 @@
+import torch
+from torch._inductor.cuda_properties import current_device as cuda_current_device
+from .xpu_properties import current_device as xpu_current_device
+
+
+def decode_device(device):
+    if device is None:
+        return torch.tensor(0.0).device  # default device
+    if isinstance(device, str):
+        device = torch.device(device)
+    if device.type == "cuda" and device.index is None:
+        return torch.device("cuda", index=cuda_current_device())
+    if device.type == "xpu" and device.index is None:
+        return torch.device("xpu", index=xpu_current_device())
+    return device

--- a/intel_extension_for_pytorch/_inductor/xpu/overrides.py
+++ b/intel_extension_for_pytorch/_inductor/xpu/overrides.py
@@ -1,0 +1,8 @@
+import torch  # noqa
+
+
+def override_decode_device():
+    from .lowering import decode_device
+    import torch._inductor.lowering
+    torch._inductor.lowering.decode_device = decode_device
+    return decode_device

--- a/intel_extension_for_pytorch/_inductor/xpu/triton_ops/autotune.py
+++ b/intel_extension_for_pytorch/_inductor/xpu/triton_ops/autotune.py
@@ -1,0 +1,285 @@
+import copy
+import functools
+import json
+import operator
+import os.path
+from typing import List
+
+import torch
+
+from torch._inductor import config
+from torch._inductor.ir import ReductionHint, TileHint
+
+from ..utils import do_bench, has_triton
+from intel_extension_for_pytorch._C import _getCurrentRawStream as get_xpu_stream
+
+if has_triton():
+    import triton
+    from triton import cdiv, Config, next_power_of_2
+    from triton.runtime.jit import KernelInterface
+    # Here we override these objects for leveraging more codes related with them from PyTorch.
+    import torch._inductor.triton_ops.autotune as _autotune
+    _autotune.cdiv = cdiv
+    _autotune.Config = Config
+    _autotune.next_power_of_2 = next_power_of_2
+    _autotune.KernelInterface = KernelInterface
+
+# NOTE: we have to import these objects after overriding in PyTorch to guarantee their correctness.
+from torch._inductor.triton_ops.autotune import (
+    CachingAutotuner,
+    hash_configs,
+    load_cached_autotuning,
+    unique_configs,
+    triton_config,
+    triton_config_reduction,
+)
+
+class XPUCachingAutotuner(CachingAutotuner):
+
+    """
+    Simplified version of Triton autotuner that has no invalidation
+    key and caches the best config to disk to improve cold start times.
+    Unlike the main triton Autotuner, this version can precompile all
+    configs, and does not rely on the Triton JIT.
+    """
+
+    def __init__(self, fn, meta, configs, save_cache_hook, mutated_arg_names):
+        super().__init__(fn, meta, configs, save_cache_hook, mutated_arg_names)
+
+    def _precompile_config(self, cfg: Config, warm_cache_only_with_cc: int):
+        """Ahead of time compile a given autotuner config."""
+        compile_meta = copy.deepcopy(self.meta)
+        for k, v in cfg.kwargs.items():
+            compile_meta["constants"][self.fn.arg_names.index(k)] = v
+        compile_meta["num_warps"] = cfg.num_warps
+        compile_meta["num_stages"] = cfg.num_stages
+        compile_meta["device_type"] = "xpu"
+        if warm_cache_only_with_cc:
+            triton.compile(
+                self.fn,
+                warm_cache_only=True,
+                cc=warm_cache_only_with_cc,
+                **compile_meta,
+            )
+            return
+
+        # load binary to the correct device
+        with torch.xpu.device(compile_meta["device"]):
+            # need to initialize context
+            torch.xpu.synchronize(torch.xpu.current_device())
+            binary = triton.compile(
+                self.fn,
+                **compile_meta,
+            )
+
+        call_args = [
+            arg
+            for i, arg in enumerate(self.fn.arg_names)
+            if i not in self.fn.constexprs
+        ]
+        def_args = list(self.fn.arg_names)
+        while def_args and def_args[-1] in cfg.kwargs:
+            def_args.pop()
+
+        scope = {
+            "grid_meta": cfg.kwargs,
+            "bin": binary,
+            "torch": torch,
+            "set_device": torch.xpu.set_device,
+            "current_device": torch.xpu.current_device,
+        }
+        exec(
+            f"""
+            def launcher({', '.join(def_args)}, grid, stream):
+                if callable(grid):
+                    grid_0, grid_1, grid_2 = grid(grid_meta)
+                else:
+                    grid_0, grid_1, grid_2 = grid
+                bin.c_wrapper(grid_0, grid_1, grid_2, bin.num_warps, bin.shared,
+                            stream, bin.cu_function, None, None, bin,
+                            {', '.join(call_args)})
+            """.lstrip(),
+            scope,
+        )
+
+        launcher = scope["launcher"]
+        launcher.config = cfg
+        return launcher
+
+    def bench(self, launcher, *args, grid):
+        """Measure the performance of a given launcher"""
+        stream = get_xpu_stream(torch.xpu.current_device())
+
+        def kernel_call():
+            if launcher.config.pre_hook is not None:
+                launcher.config.pre_hook(
+                    {**zip(self.arg_names, args), **launcher.config.kwargs}
+                )
+            launcher(
+                *args,
+                grid=grid,
+                stream=stream,
+            )
+
+        return do_bench(kernel_call, rep=40, fast_flush=True)
+
+
+def cached_autotune(
+    configs: List[Config],
+    meta,
+    filename=None,
+):
+    """
+    A copy of triton.autotune that calls our subclass.  Our subclass
+    has additional debugging, error handling, and on-disk caching.
+    """
+    configs = unique_configs(configs)
+    assert len(configs) == 1 or filename
+
+    # on disk caching logic
+    if filename is not None and len(configs) > 1:
+        cache_filename = os.path.splitext(filename)[0] + ".best_config"
+        configs_hash = hash_configs(configs)
+        best_config = load_cached_autotuning(cache_filename, configs_hash, configs)
+        if best_config:
+            configs = [best_config]
+
+        def save_cache_hook(cfg):
+            with open(cache_filename, "w") as fd:
+                fd.write(json.dumps({**cfg.kwargs, "configs_hash": configs_hash}))
+
+    else:
+        save_cache_hook = None
+
+    mutated_arg_names = meta.pop("mutated_arg_names", ())
+
+    def decorator(fn):
+        return XPUCachingAutotuner(
+            fn,
+            meta=meta,
+            configs=configs,
+            save_cache_hook=save_cache_hook,
+            mutated_arg_names=mutated_arg_names,
+        )
+
+    return decorator
+
+
+def pointwise(size_hints, meta, tile_hint=None, filename=None):
+    """
+    Construct @triton.heuristics() based on size_hints.
+    """
+    numel = functools.reduce(operator.mul, size_hints)
+    bs = max(256, min(numel // 128, 1024))
+
+    if len(size_hints) == 1:
+        return cached_autotune([triton_config(size_hints, bs)], meta=meta)
+    if len(size_hints) == 2:
+        if (
+            not config.triton.autotune_pointwise or tile_hint == TileHint.SQUARE
+        ) and not config.max_autotune:
+            return cached_autotune([triton_config(size_hints, 32, 32)], meta=meta)
+        return cached_autotune(
+            [
+                triton_config(size_hints, 32, 32),
+                triton_config(size_hints, 64, 64),  # ~8% better for fp16
+                triton_config(size_hints, 256, 16),
+                triton_config(size_hints, 16, 256),
+                triton_config(size_hints, bs, 1),
+                triton_config(size_hints, 1, bs),
+            ],
+            meta=meta,
+            filename=filename,
+        )
+    if len(size_hints) == 3:
+        if not config.triton.autotune_pointwise:
+            return cached_autotune([triton_config(size_hints, 16, 16, 16)], meta=meta)
+        return cached_autotune(
+            [
+                triton_config(size_hints, 16, 16, 16),
+                triton_config(size_hints, 64, 8, 8),
+                triton_config(size_hints, 8, 64, 8),
+                triton_config(size_hints, 8, 8, 64),
+                triton_config(size_hints, bs, 1, 1),
+                triton_config(size_hints, 1, bs, 1),
+                triton_config(size_hints, 1, 1, bs),
+            ],
+            meta=meta,
+            filename=filename,
+        )
+    raise NotImplementedError(f"size_hints: {size_hints}")
+
+
+def reduction(size_hints, reduction_hint=False, meta=None, filename=None):
+    """args to @triton.heuristics()"""
+    assert meta is not None
+    rnumel = size_hints[-1]
+    if len(size_hints) == 2:
+        contiguous_config = triton_config_reduction(
+            size_hints, 1, (rnumel if 256 <= rnumel < 2048 else 2048), num_stages=1
+        )
+        outer_config = triton_config_reduction(size_hints, 128, 8)
+        tiny_config = triton_config_reduction(
+            size_hints, 2 * (256 // rnumel) if rnumel <= 256 else 1, min(rnumel, 2048)
+        )
+        if config.max_autotune:
+            pass  # skip all these cases
+        elif reduction_hint == ReductionHint.INNER:
+            return cached_autotune([contiguous_config], meta=meta)
+        elif reduction_hint == ReductionHint.OUTER:
+            return cached_autotune([outer_config], meta=meta)
+        elif reduction_hint == ReductionHint.OUTER_TINY:
+            return cached_autotune([tiny_config], meta=meta)
+        if not config.triton.autotune_pointwise:
+            return cached_autotune(
+                [triton_config_reduction(size_hints, 32, 128)], meta=meta
+            )
+        return cached_autotune(
+            [
+                contiguous_config,
+                outer_config,
+                tiny_config,
+                triton_config_reduction(size_hints, 64, 64),
+                triton_config_reduction(size_hints, 8, 512),
+            ],
+            meta=meta,
+            filename=filename,
+        )
+    raise NotImplementedError(f"size_hints: {size_hints}")
+
+
+def persistent_reduction(size_hints, reduction_hint=False, meta=None, filename=None):
+    xnumel, rnumel = size_hints
+
+    configs = [
+        triton_config_reduction(size_hints, xblock, rnumel)
+        for xblock in (1, 8, 32, 128)
+        if rnumel * xblock <= 4096 and xblock <= xnumel
+    ]
+
+    # TODO(jansel): we should be able to improve these heuristics
+    if reduction_hint == ReductionHint.INNER and rnumel >= 256:
+        configs = configs[:1]
+    elif reduction_hint == ReductionHint.OUTER:
+        configs = configs[-1:]
+    elif reduction_hint == ReductionHint.OUTER_TINY:
+        configs = [
+            triton_config_reduction(
+                size_hints, 2 * (256 // rnumel) if rnumel <= 256 else 1, rnumel
+            )
+        ]
+
+    return cached_autotune(
+        configs,
+        meta=meta,
+        filename=filename,
+    )
+
+
+def template(num_stages, num_warps, meta, filename=None):
+    """
+    Compile a triton template
+    """
+    return cached_autotune(
+        [triton.Config({}, num_stages=num_stages, num_warps=num_warps)], meta=meta
+    )

--- a/intel_extension_for_pytorch/_inductor/xpu/utils.py
+++ b/intel_extension_for_pytorch/_inductor/xpu/utils.py
@@ -1,0 +1,121 @@
+import functools
+import time
+
+import torch
+
+
+def do_bench(fn, warmup=25, rep=100, grad_to_none=None,
+             quantiles=None,
+             fast_flush=True,
+             return_mode="mean"):
+    assert return_mode in ["min", "max", "mean", "median"]
+    """
+    Benchmark the runtime of the provided function. By default, return the median runtime of :code:`fn` along with
+    the 20-th and 80-th performance percentile.
+
+    :param fn: Function to benchmark
+    :type fn: Callable
+    :param warmup: Warmup time (in ms)
+    :type warmup: int
+    :param rep: Repetition time (in ms)
+    :type rep: int
+    :param grad_to_none: Reset the gradient of the provided tensor to None
+    :type grad_to_none: torch.tensor, optional
+    :param quantiles: Performance percentile to return in addition to the median.
+    :type quantiles: list[float]
+    :param fast_flush: Use faster kernel to flush L2 between measurements
+    :type fast_flush: bool
+    """
+
+    fn()
+    torch.xpu.synchronize()
+
+    # We maintain a buffer of 256 MB that we clear
+    # before each kernel call to make sure that the L2
+    # doesn't contain any input data before the run
+    if fast_flush:
+        cache = torch.empty(int(256e6 // 4), dtype=torch.int, device='xpu')
+    else:
+        cache = torch.empty(int(256e6), dtype=torch.int8, device='xpu')
+
+    # Estimate the runtime of the function
+    start_event = torch.xpu.Event(enable_timing=True)
+    end_event = torch.xpu.Event(enable_timing=True)
+    start_event.record()
+    for _ in range(5):
+        cache.zero_()
+        fn()
+    end_event.record()
+    torch.xpu.synchronize()
+    estimate_ms = start_event.elapsed_time(end_event) / 5
+
+    # compute number of warmup and repeat
+    n_warmup = max(1, int(warmup / estimate_ms))
+    n_repeat = max(1, int(rep / estimate_ms))
+    start_event = [torch.xpu.Event(enable_timing=True) for i in range(n_repeat)]
+    end_event = [torch.xpu.Event(enable_timing=True) for i in range(n_repeat)]
+    # Warm-up
+    for _ in range(n_warmup):
+        fn()
+    # Benchmark
+    for i in range(n_repeat):
+        # we don't want `fn` to accumulate gradient values
+        # if it contains a backward pass. So we clear the
+        # provided gradients
+        if grad_to_none is not None:
+            for x in grad_to_none:
+                x.grad = None
+        # we clear the L2 cache before each run
+        cache.zero_()
+        # record time of `fn`
+        start_event[i].record()
+        fn()
+        end_event[i].record()
+    # Record clocks
+    torch.xpu.synchronize()
+    times = torch.tensor([s.elapsed_time(e) for s, e in zip(start_event, end_event)], dtype=torch.float)
+    if quantiles is not None:
+        ret = torch.quantile(times, torch.tensor(quantiles, dtype=torch.float)).tolist()
+        if len(ret) == 1:
+            ret = ret[0]
+        return ret
+    return getattr(torch, return_mode)(times).item()
+
+
+@functools.lru_cache(None)
+def has_triton():
+    if not torch.xpu.is_available():
+        return False
+    try:
+        import triton
+
+        return triton is not None
+    except ImportError:
+        return False
+
+
+def synchronize():
+    if torch.xpu.is_available():
+        torch.xpu.synchronize()
+
+
+def timed(model, example_inputs, times=1):
+    synchronize()
+    torch.manual_seed(1337)
+    # Set manual seed to XPU explictly.
+    torch.xpu.manual_seed(1337)
+    t0 = time.perf_counter()
+    for _ in range(times):
+        result = model(*example_inputs)
+        synchronize()
+    t1 = time.perf_counter()
+    # GC the result after timing
+    assert result is not None
+    return t1 - t0
+
+
+def print_performance(fn, args=(), times=10, repeat=10, baseline=1.0):
+    timings = torch.tensor([timed(fn, args, times) for _ in range(repeat)])
+    took = torch.median(timings)
+    print(f"{took/baseline:.6f}")
+    return took

--- a/intel_extension_for_pytorch/_inductor/xpu/xpu_properties.py
+++ b/intel_extension_for_pytorch/_inductor/xpu/xpu_properties.py
@@ -1,0 +1,8 @@
+import torch
+
+
+def current_device():
+    from torch._inductor.cuda_properties import _compile_worker_current_device
+    if _compile_worker_current_device is not None:
+        return _compile_worker_current_device
+    return torch.xpu.current_device()


### PR DESCRIPTION
# Motivation

- Empower IPEX-GPU by supporting Intel XPU Backend for Inductor to benefit from `torch.compile`
- Integrate Intel XPU Backend for Inductor at Inductor IR level to reuse most features and optimizations of Inductor.

# Solution
Following @EikanWang 's design [Extend inductor to support the third-party backend](https://github.com/pytorch/pytorch/pull/100706), we register the Intel XPU backend to the inductor.

Let us elaborate on this design first:
1. The backends of Inductor have two common interfaces to generate backend-specific code - `Scheduling` and `WrapperCodeGen`. Therefore, Intel XPU Backend provides `XPUTritonScheduling` and `XPUTrtionWrapperCodeGen` for its particular code generation logic by following the design, while the two XPU-specific classes inherit from Inductor `BaseScheduling` and `WrapperCodeGen` to reuse code as much as possible.
2. With the two key classes ready, we register Intel XPU Backend to Inductor at runtime by the interface of [PR 100706 - Extend inductor to support the third-party backend](https://github.com/pytorch/pytorch/pull/100706). As the `xpu` has been a device of PyTorch for Intel devices, the Inductor IR will be lowered for Intel XPU Backend if the input tensors are `xpu`

[**Note**]: With this design, we can easily register triton XPU backend to inductor. But there are some **limitations** listed as below:
1. For mm op using `TritonTemplate`, we decide to use `XPUTritonTemplate`, which inherits `XPUTritonTemplateKernel` that inherits from `XPUTritonKernel`, to override these mm ops from IPEX side. This is an open issue.
2. Considering indcutor's `CachingAutotuner` is specified by CUDA, we need to implement `XPUCachingAutotuner` in IPEX side. So we have to override `pointwise`'s, `reduction`'s, and` persistent_reduction`'s heuristics and use them in our `XPUTritonKernel`.
3. Similar as `CachingAutotuner`, we should have our own `XPUAsyncCompile` to replace `AsyncCompile`.
4. We have to override `decode_device` in IPEX since there are some hardcodes related to CUDA in the inductor. This is an open issue.
5. For cpp wrapper codegen on XPU, we ignore it this time.

# Additional Context
We list a task list need to be completed as below:
- [x] Register `XPUTritonScheduling` & `XPUTritonWrapperCodeGen` to inductor.
- [x] Implement `XPUCachingAutotuner` for our own `pointwise`'s, `reduction`'s, and `persistent_reduction`'s heuristics
- [x] Implement our own `XPUAsyncCompile` to replace `AsyncCompile`.
- [x] Co-work with stock branch PR [Extend inductor to support the third-party backend](https://github.com/pytorch/pytorch/pull/100706) to validate the availability for @EikanWang 's design.
- [x] Debug code for inductor UT pass rate.
