### PR TITLE
Fix weight-only quantization on OPT model

### DIFF
--- a/examples/cpu/inference/python/llm/single_instance/run_quantization.py
+++ b/examples/cpu/inference/python/llm/single_instance/run_quantization.py
@@ -530,11 +530,18 @@ elif args.ipex_weight_only_quantization:
             position_ids.unsqueeze(0),
         )
     elif model.example_inputs_mode == EXAMPLE_INPUTS_MODE.KV_MASK:
-        example_inputs = (
-            input_ids.unsqueeze(0),
-            tuple(global_past_key_value),
-            attention_mask.unsqueeze(0),
-        )
+        if re.search("OPT", config.architectures[0], re.IGNORECASE):
+            example_inputs = (
+                input_ids.unsqueeze(0),
+                attention_mask.unsqueeze(0),
+                tuple(global_past_key_value),
+            )
+        else: 
+            example_inputs = (
+                input_ids.unsqueeze(0),
+                tuple(global_past_key_value),
+                attention_mask.unsqueeze(0),
+            )
     elif model.example_inputs_mode == EXAMPLE_INPUTS_MODE.MASK_KV_ENC:
         last_hidden_state = torch.rand([1, 32, 2048])
         global_past_key_value = [


### PR DESCRIPTION
I have opened an issue where ipex reports errors when running weight-only quantization on OPT models (#501).

I tried to fix this issue in this PR.

In the transformers (>=4.31.0), in the `forward` function of `class OPTDecoder`, the sequence of input parameters is [`(input_ids, attention_mask, head_mask, past_key_values, ...)`](https://github.com/huggingface/transformers/blob/main/src/transformers/models/opt/modeling_opt.py#L976), while the sequence of input parameters of other models (e.g., Falcon) is [`(input_ids, past_key_values, attention_mask, ...)`](https://github.com/huggingface/transformers/blob/main/src/transformers/models/falcon/modeling_falcon.py#L1028).