### PR TITLE
Extra cd .. is not required

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -20,7 +20,6 @@
   $ cd intel-extension-for-pytorch
   $ git submodule sync
   $ git submodule update --init --recursive
-  $ cd ..
   $ DOCKER_BUILDKIT=1 docker build -f docker/Dockerfile.compile -t intel-extension-for-pytorch:main .
   ```
 


### PR DESCRIPTION
docker build is supposed to happen inside intel-extension-for-pytorch directory