### PR TITLE
Fix AVX515 FP16 build issues

### DIFF
--- a/csrc/cpu/aten/kernels/MaskedMultiHeadAttentionKrnl.cpp
+++ b/csrc/cpu/aten/kernels/MaskedMultiHeadAttentionKrnl.cpp
@@ -425,7 +425,7 @@ void mul_attenion_weights_and_value_of_head_half(
   auto hsi = 0;
   auto vec_size = 32; // 512/16
   for (hsi = 0; hsi <= head_size - vec_size; hsi += vec_size) {
-    auto attn_w_vec = _mm512_set1_ph(attn_w);
+    auto attn_w_vec = _mm512_set1_ph(static_cast<_Float16>(static_cast<float>(attn_w)));
     auto v_vec = _mm512_loadu_ph(v_ptr_start + hsi);
     if (accumulate) {
       auto attn_out_vec = _mm512_loadu_ph(attn_out_start + hsi);

--- a/csrc/cpu/aten/kernels/WoqTppKrnl.cpp
+++ b/csrc/cpu/aten/kernels/WoqTppKrnl.cpp
@@ -751,7 +751,7 @@ struct GemmMicroKernel<
         if constexpr (scale_as_post_op) {
           vc[i] = V::fmadd(vscales[col / CBLOCK][col % CBLOCK], vc[i], vc_old);
         } else {
-          vc[i] = V::fmadd(V::set1(1.0f), vc[i], vc_old);
+          vc[i] = V::fmadd(V::set1(static_cast<_Float16>(1.0f)), vc[i], vc_old);
         }
       } else if constexpr (scale_as_post_op) {
         vc[i] = V::mul(vscales[col / CBLOCK][col % CBLOCK], vc[i]);

--- a/csrc/cpu/vec/vec512/perf_kernel/add_softmax.h
+++ b/csrc/cpu/vec/vec512/perf_kernel/add_softmax.h
@@ -195,13 +195,13 @@ inline void _dil_div_add_reduce_max_fusion_kernel_half(
     const int& size,
     at::Half* out,
     at::Half& max) {
-  auto vec_ps_min = _mm512_set1_ph((at::Half)(-65504.0));
+  auto vec_ps_min = _mm512_set1_ph(static_cast<_Float16>(-65504.0));
   auto vec_a = vec_ps_min;
   auto vec_b = vec_ps_min;
   auto vec_out = vec_ps_min;
 
   int i = 0;
-  auto vec_r_dim_per_head = _mm512_set1_ph((at::Half)(1.0 / dim_per_head));
+  auto vec_r_dim_per_head = _mm512_set1_ph(static_cast<_Float16>(1.0 / dim_per_head));
   for (; i <= size - 32; i += 32) {
     vec_a = _loadu_half(a + i);
     vec_b = _loadu_half(b + i);
@@ -304,9 +304,9 @@ inline void _dil_exp_reduce_sum_fusion_kernel_half(
     const int& size,
     at::Half* out,
     at::Half& val) {
-  static auto vec_zero = _mm512_set1_ph((at::Half)(0.0));
-  auto vec_max = _mm512_set1_ph(val);
-  auto vec_sum = _mm512_set1_ph(at::Half(0.0));
+  static auto vec_zero = _mm512_set1_ph(static_cast<_Float16>(0.0));
+  auto vec_max = _mm512_set1_ph(static_cast<_Float16>(static_cast<float>(val)));
+  auto vec_sum = _mm512_set1_ph(static_cast<_Float16>(0.0));
   __m512h vec_a = {};
   __m512h vec_out = {};
 
@@ -364,7 +364,7 @@ inline void _dil_normalization_kernel_half(
     const at::Half& sum,
     const int& size,
     at::Half* out) {
-  auto vec_sum = _mm512_set1_ph(sum);
+  auto vec_sum = _mm512_set1_ph(static_cast<_Float16>(static_cast<float>(sum)));
   __m512h vec_a = {};
   __m512h vec_out = {};
 


### PR DESCRIPTION
Seeing the following build errors with GCC 13.2 and PyTorch 2.2 on a Xeon Gold 6150:

```
error: invalid user-defined conversion from 'c10::Half' to '_Float16' [-fpermissive]
error: cannot convert 'float' to 'VecOps<__vector(32) _Float16>::ST' {aka '_Float16'}
```

The following flags are reported from /proc/cpuinfo:

```
flags           : fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc art arch_perfmon pebs bts rep_good nopl xtopology nonstop_tsc cpuid aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 sdbg fma cx16 xtpr pdcm pcid dca sse4_1 sse4_2 x2apic movbe popcnt tsc_deadline_timer aes xsave avx f16c rdrand lahf_lm abm 3dnowprefetch cpuid_fault epb cat_l3 cdp_l3 invpcid_single pti intel_ppin ssbd mba ibrs ibpb stibp tpr_shadow vnmi flexpriority ept vpid fsgsbase tsc_adjust bmi1 hle avx2 smep bmi2 erms invpcid rtm cqm mpx rdt_a avx512f avx512dq rdseed adx smap clflushopt clwb intel_pt avx512cd avx512bw avx512vl xsaveopt xsavec xgetbv1 xsaves cqm_llc cqm_occup_llc cqm_mbm_total cqm_mbm_local dtherm ida arat pln pts pku ospke md_clear flush_l1d arch_capabilities
```