### PR TITLE
Fix `AttributeError: module 'triton.language.math' has no attribute`

### DIFF
--- a/intel_extension_for_pytorch/_inductor/xpu/codegen/triton.py
+++ b/intel_extension_for_pytorch/_inductor/xpu/codegen/triton.py
@@ -300,6 +300,7 @@ class XPUTritonKernel(TritonKernel):
                 f"""
                     import triton
                     import triton.language as tl
+                    from triton.language.extra.intel import libdevice
                     from torch._inductor.ir import ReductionHint
                     from torch._inductor.ir import TileHint
                     from intel_extension_for_pytorch._inductor.xpu.triton_heuristics import AutotuneHint, {heuristics}


### PR DESCRIPTION
The change is caused by https://github.com/intel/intel-xpu-backend-for-triton/commit/0bd315f6be50cd8b8f9a25107bd4aca5f69bb853.