### PR TITLE
Add an API to get current global free memory of XPU

### DIFF
--- a/csrc/gpu/aten/core/Device.cpp
+++ b/csrc/gpu/aten/core/Device.cpp
@@ -94,5 +94,9 @@ int prefetch_device_has_fp64_dtype(int device_id, bool& has_fp64) noexcept {
   return xpu::dpcpp::dpcppPrefetchDeviceHasFP64Dtype(device_id, has_fp64);
 }
 
+uint64_t getDeviceFreeMemory(DeviceIndex device_id) {
+  return xpu::dpcpp::dpcppGetDeviceFreeMemory(device_id);
+}
+
 } // namespace dpcpp
 } // namespace xpu

--- a/csrc/gpu/aten/core/Device.h
+++ b/csrc/gpu/aten/core/Device.h
@@ -83,5 +83,7 @@ IPEX_API int prefetch_device_has_fp64_dtype(
     int device_id,
     bool& has_fp64) noexcept;
 
+IPEX_API uint64_t getDeviceFreeMemory(DeviceIndex device_id);
+
 } // namespace dpcpp
 } // namespace xpu

--- a/csrc/gpu/runtime/Device.cpp
+++ b/csrc/gpu/runtime/Device.cpp
@@ -537,5 +537,17 @@ int dpcppPrefetchDeviceHasFP64Dtype(int device_id, bool& has_fp64) noexcept {
   return xpu::dpcpp::dpcppGetDeviceHasFP64DtypeFork(device_id, has_fp64);
 }
 
+uint64_t dpcppGetDeviceFreeMemory(DeviceId device_id) {
+  const auto device = dpcppGetRawDevice(device_id);
+
+  if (device.has(sycl::aspect::ext_intel_free_memory)) {
+    return device.get_info<sycl::ext::intel::info::device::free_memory>();
+  } else {
+    TORCH_WARN_ONCE(
+        "This device does not support free memory information. You can try again with ZES_ENABLE_SYSMAN=1.");
+    return 0;
+  }
+}
+
 } // namespace dpcpp
 } // namespace xpu

--- a/csrc/gpu/runtime/Device.h
+++ b/csrc/gpu/runtime/Device.h
@@ -41,5 +41,7 @@ int dpcppPrefetchDeviceHasFP64Dtype(int device_id, bool& has_fp64) noexcept;
 
 bool dpcppGetDeviceHasXMX(DeviceId device_id = -1) noexcept;
 
+uint64_t dpcppGetDeviceFreeMemory(DeviceId device_id);
+
 } // namespace dpcpp
 } // namespace xpu

--- a/intel_extension_for_pytorch/csrc/xpu/Module.cpp
+++ b/intel_extension_for_pytorch/csrc/xpu/Module.cpp
@@ -395,6 +395,15 @@ PyObject* THPModule_memorySnapshot(PyObject* _unused, PyObject* noargs) {
   END_HANDLE_TH_ERRORS
 }
 
+PyObject* THPModule_getFreeMemory(PyObject* _unused, PyObject* arg) {
+  HANDLE_TH_ERRORS
+  THPUtils_assert(
+      THPUtils_checkLong(arg), "invalid argument to get_free_memory");
+  const int device = (int)THPUtils_unpackLong(arg);
+  return THPUtils_packUInt64(xpu::dpcpp::getDeviceFreeMemory(device));
+  END_HANDLE_TH_ERRORS
+}
+
 static PyObject* set_autocast_xpu_enabled(PyObject* _unused, PyObject* arg) {
   HANDLE_TH_ERRORS
   if (!PyBool_Check(arg)) {
@@ -530,6 +539,7 @@ static struct PyMethodDef _THPModule_methods[] = {
     {"get_autocast_xpu_dtype", get_autocast_xpu_dtype, METH_NOARGS, nullptr},
     {"_from_usm", THPModule_fromUSM, METH_VARARGS, nullptr},
     {"_to_usm", THPModule_toUSM, METH_O, nullptr},
+    {"_getFreeMemory", THPModule_getFreeMemory, METH_O, nullptr},
     {nullptr}};
 
 std::string get_dev_type(const DeviceInfo& info) {


### PR DESCRIPTION
This PR fixes https://github.com/intel/intel-extension-for-pytorch/issues/522, using `ZES_ENABLE_SYSMAN` environment variable to make it work. 
It also adds a `torch.xpu.mem_get_info()` method which behaves the same as `torch.cuda.mem_get_info()`.

Sadly it only works under root. I have opened https://github.com/oneapi-src/level-zero/issues/133 but got no response yet.

Any ideas?