### PR TITLE
Update examples/cpu/inference/python/llm/README.md

### DIFF
--- a/examples/cpu/inference/python/llm/README.md
+++ b/examples/cpu/inference/python/llm/README.md
@@ -82,6 +82,10 @@ git submodule update --init --recursive
 
 # Build an image with the provided Dockerfile by compiling Intel® Extension for PyTorch\* from source
 DOCKER_BUILDKIT=1 docker build -f examples/cpu/inference/python/llm/Dockerfile --build-arg COMPILE=ON -t ipex-llm:main .
+# Working behind a corporate HTTP proxy makes everything harder, try add http/https proxy by build args
+DOCKER_BUILDKIT=1 docker build -f examples/cpu/inference/python/llm/Dockerfile --build-arg COMPILE=ON \
+    --build-arg http_proxy=<proxy host>:<proxy port> --build-arg https_proxy=<proxy host>:<proxy port> \
+    -t ipex-llm:main .
 
 # Run the container with command below
 docker run --rm -it --privileged ipex-llm:main bash


### PR DESCRIPTION
docker build behind a corporate HTTP proxy makes curl failure so add more explain when user environment needs proxy.

215.5 curl: (28) Failed to connect to repo.anaconda.com port 443 after 214840 ms: Connection timed out ------
Dockerfile:39
--------------------
  38 |
  39 | >>> RUN curl -fsSL -v -o miniconda.sh -O https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh  && \
  40 | >>>     bash miniconda.sh -b -p ./miniconda3 && \
  41 | >>>     rm miniconda.sh && \
  42 | >>>     echo "source ~/miniconda3/bin/activate" >> ./.bashrc
  43 |
--------------------