### PR TITLE
[Triton] change target[1] to sycl_device to get arch properties from Triton side

### DIFF
--- a/intel_extension_for_pytorch/_inductor/xpu/triton_heuristics.py
+++ b/intel_extension_for_pytorch/_inductor/xpu/triton_heuristics.py
@@ -128,7 +128,7 @@ class XPUCachingAutotuner(CachingAutotuner):
                 ),
             )
 
-            target = (compile_meta["device_type"], cc)
+            target = (compile_meta["device_type"], torch.xpu.device(torch.xpu.current_device()).sycl_device)
             options = {
                 "num_warps": compile_meta["num_warps"],
                 "num_stages": compile_meta["num_stages"],


### PR DESCRIPTION
Since we can get device architecture by sycl::device from 2024.1. https://github.com/intel/llvm/blob/b963e894678247d99b03f18d00ae7bdc4ca883da/sycl/include/sycl/ext/oneapi/experimental/device_architecture.hpp#L18 We are trying to get arch infomations from Triton side to decouple with IPEX. This may reduce the maintaining efforts. This is only for Triton testing now.