### PR TITLE
[xpu] [Windows] Do not reset `%LIB%` on Windows after building torch

### DIFF
--- a/scripts/compile_bundle.bat
+++ b/scripts/compile_bundle.bat
@@ -126,7 +126,7 @@ if defined CONDA_PREFIX (
      set "CMAKE_PREFIX_PATH=%VIRTUAL_ENV%"
 )
 set "CMAKE_INCLUDE_PATH=%CONDA_PREFIX%\Library\include"
-set "LIB=%CONDA_PREFIX%\Library\lib;%LIB%"
+set "LIB=%LIB%;%CONDA_PREFIX%\Library\lib"
 set "USE_NUMA=0"
 set "USE_CUDA=0"
 python setup.py clean
@@ -134,7 +134,6 @@ python setup.py bdist_wheel
 
 set "USE_CUDA="
 set "USE_NUMA="
-set "LIB="
 set "CMAKE_INCLUDE_PATH="
 set "CMAKE_PREFIX_PATH="
 call conda remove mkl-static mkl-include -y


### PR DESCRIPTION
When I'm building ipex on Windows, I noticed that torchaudio, torchvision and ipex will fail after successfully building torch. After I removed the block building PyTorch and restart `cmd.exe`, the rest was compiled successfully. I forgot to save the error message, but the main idea is that lib not found (like kernel32.lib).
Then I noticed in `compile_bundle.bat` that `set "LIB="` will actually **delete** this variable! Then the compiler won't find static libs in default VS lib paths, so kernel32.lib will not be found.