### PR TITLE
Revert "[Triton] change target[1] to sycl_device to get arch properties from Triton side"

### DIFF
--- a/intel_extension_for_pytorch/_inductor/xpu/triton_heuristics.py
+++ b/intel_extension_for_pytorch/_inductor/xpu/triton_heuristics.py
@@ -128,7 +128,7 @@ class XPUCachingAutotuner(CachingAutotuner):
                 ),
             )
 
-            target = (compile_meta["device_type"], torch.xpu.device(torch.xpu.current_device()).sycl_device)
+            target = (compile_meta["device_type"], cc)
             options = {
                 "num_warps": compile_meta["num_warps"],
                 "num_stages": compile_meta["num_stages"],


### PR DESCRIPTION
Reverts intel/intel-extension-for-pytorch#590