### PR TITLE
added import os for exit() to fix NameError

### DIFF
--- a/intel_extension_for_pytorch/__init__.py
+++ b/intel_extension_for_pytorch/__init__.py
@@ -1,6 +1,6 @@
 # This Python file uses the following encoding: utf-8
 import re
-
+import os
 import torch
 
 
@@ -33,7 +33,7 @@ if torch_version == "" or ipex_version == "" or torch_version != ipex_version:
         + f"{ipex_version}.*, but PyTorch {torch.__version__} is found. "
         + "Please switch to the matching version and run again."
     )
-    exit(127)
+    os.exit(127)
 
 
 import os


### PR DESCRIPTION
Name error coming up on code if reached to that line, via torch version mismatch

<img width="912" alt="image" src="https://github.com/intel/intel-extension-for-pytorch/assets/60128411/a8ee2bea-34ff-45dd-aa45-af968bbe3a02">
