### PR TITLE
docker: Update prebuilt Dockerfile

### DIFF
--- a/docker/Dockerfile.prebuilt
+++ b/docker/Dockerfile.prebuilt
@@ -28,15 +28,15 @@ RUN ${PYTHON} -m pip --no-cache-dir install --upgrade \
 # Some TF tools expect a "python" binary
 RUN ln -s $(which ${PYTHON}) /usr/local/bin/python
 
-ARG IPEX_VERSION=2.3.100
-ARG PYTORCH_VERSION=2.3.0
-ARG TORCHAUDIO_VERSION=2.3.0
-ARG TORCHVISION_VERSION=0.18.0
-ARG TORCH_CPU_URL=https://download.pytorch.org/whl/cpu/torch_stable.html
+ARG IPEX_VERSION=2.4.0
+ARG PYTORCH_VERSION=2.4.0
+ARG TORCHAUDIO_VERSION=2.4.0
+ARG TORCHVISION_VERSION=0.19.0
+ARG TORCH_CPU_URL=https://download.pytorch.org/whl/cpu/
 
 RUN \
-    python -m pip install --no-cache-dir \
-    torch==${PYTORCH_VERSION}+cpu torchvision==${TORCHVISION_VERSION}+cpu torchaudio==${TORCHAUDIO_VERSION}+cpu -f ${TORCH_CPU_URL} && \
+    python -m pip install --extra-index-url ${TORCH_CPU_URL} --no-cache-dir \
+    torch==${PYTORCH_VERSION}+cpu torchvision==${TORCHVISION_VERSION}+cpu torchaudio==${TORCHAUDIO_VERSION}+cpu && \
     python -m pip install --no-cache-dir \
     intel_extension_for_pytorch==${IPEX_VERSION}
 


### PR DESCRIPTION
1. Bump pytorch and ipex to 2.4.0
2. update the link of `TORCH_CPU_URL`. `https://download.pytorch.org/whl/cpu/torch_stable.html` is deprecated since torch 2.4. See https://github.com/pytorch/pytorch/issues/133128.