### PR TITLE
Update IPEX_Getting_Started.ipynb

### DIFF
--- a/examples/cpu/inference/python/jupyter-notebooks/IPEX_Getting_Started.ipynb
+++ b/examples/cpu/inference/python/jupyter-notebooks/IPEX_Getting_Started.ipynb
@@ -70,24 +70,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!wget https://raw.githubusercontent.com/intel/intel-extension-for-pytorch/master/examples/cpu/inference/python/resnet50_general_inference_script.py"
-   ]
-  },
-  {
-   "attachments": {},
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Check PyTorch and Intel® Extension for PyTorch (IPEX) verson in current ipython kernel"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "run ../../version_check.py"
+    "!wget https://raw.githubusercontent.com/intel/intel-extension-for-pytorch/main/examples/cpu/inference/python/python-scripts/resnet50_general_inference_script.py"
    ]
   },
   {


### PR DESCRIPTION
Fixes ONSAM-2014 and ONSAM-2015.
ONSAM-2014: Updated URL to https://raw.githubusercontent.com/intel/intel-extension-for-pytorch/main/examples/cpu/inference/python/python-scripts/resnet50_general_inference_script.py in notebook.
ONSAM-2015: Removes version_check.py from notebook.