### PR TITLE
A small typo in the python os library usage

### DIFF
--- a/intel_extension_for_pytorch/__init__.py
+++ b/intel_extension_for_pytorch/__init__.py
@@ -33,7 +33,7 @@ if torch_version == "" or ipex_version == "" or torch_version != ipex_version:
         + f"{ipex_version}.*, but PyTorch {torch.__version__} is found. "
         + "Please switch to the matching version and run again."
     )
-    os.exit(127)
+    os._exit(127)
 
 
 import os


### PR DESCRIPTION
There is no method called exit() in os. It is named _exit()

Source:
https://stackoverflow.com/questions/72010825/python-attributeerror-module-os-has-no-attribute-exit