### PR TITLE
fix the exit typo

### DIFF
--- a/intel_extension_for_pytorch/__init__.py
+++ b/intel_extension_for_pytorch/__init__.py
@@ -33,7 +33,7 @@ if torch_version == "" or ipex_version == "" or torch_version != ipex_version:
         + f"{ipex_version}.*, but PyTorch {torch.__version__} is found. "
         + "Please switch to the matching version and run again."
     )
-    os.exit(127)
+    os._exit(127)
 
 
 import os


### PR DESCRIPTION
It should be os._exit() instead os.exit: https://docs.python.org/3/library/os.html#os._exit