### PR TITLE
Correct import for error handling

### DIFF
--- a/intel_extension_for_pytorch/__init__.py
+++ b/intel_extension_for_pytorch/__init__.py
@@ -1,6 +1,6 @@
 # This Python file uses the following encoding: utf-8
 import re
-import os
+import sys
 import torch
 
 
@@ -33,7 +33,7 @@ if torch_version == "" or ipex_version == "" or torch_version != ipex_version:
         + f"{ipex_version}.*, but PyTorch {torch.__version__} is found. "
         + "Please switch to the matching version and run again."
     )
-    os.exit(127)
+    sys.exit(127)
 
 
 import os


### PR DESCRIPTION
The exit utility is in sys standard library.

Documents:

- https://docs.python.org/3/library/os.html#os._exit
- https://docs.python.org/3/library/sys.html#sys.exit